### PR TITLE
Particles splits script

### DIFF
--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -97,7 +97,7 @@ def load_overflow_data(path_to_split_log_files, tree_size):
             warnings.simplefilter('ignore')
             file_data = np.loadtxt(f'{path_to_split_log_files}/{filename}', dtype=np.int64)
             # We need to reshape if there is only one row in the splits file
-            if len(file_data.shape) == 1:
+            if (len(file_data.shape) == 1) and (file_data.shape[0] != 0):
                 file_data = file_data.reshape(1, -1)
         for row in file_data:
             _, new_prog_id, old_prog_id, count, tree = row

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -500,9 +500,13 @@ def save(split_dictionary, file_path):
     if comm_rank == 0:
         with h5py.File(file_path, 'r') as file:
             keys = file['SplitInformation/Keys'][:]
-            assert np.unique(keys).shape[0] == keys.shape[0]
+            keys_unique = np.unique(keys).shape[0] == keys.shape[0]
             values = file['SplitInformation/Values'][:]
-            assert np.unique(values).shape[0] == values.shape[0]
+            values_unique = np.unique(values).shape[0] == values.shape[0]
+        if not (keys_unique and values_unique):
+            os.remove(file_path)
+            # Not need for MPI_ABORT since other ranks are finished anyway
+            raise RuntimeError('Keys/Values were not unique')
 
 def assign_task_based_on_id(ids):
     """

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -319,7 +319,8 @@ def update_overflow_split_trees(split_data, overflow_data=None):
         split_data['trees'] = trees
         split_data['progenitor_ids'] = progenitor_ids
 
-    assert np.min(split_data['trees']) >= 0
+    if split_data['trees'].shape[0] > 0:
+        assert np.min(split_data['trees']) >= 0
 
     return split_data
 

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -41,25 +41,25 @@ def load_hbt_config(config_path):
     with open(config_path) as file:
         for line in file:
             if 'MinSnapshotIndex' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['MinSnapshotIndex'] = int(line.split()[-1])
             if 'MaxSnapshotIndex' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['MaxSnapshotIndex'] = int(line.split()[-1])
             if 'SnapshotIdList' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['SnapshotIdList'] = np.array(line.split()[1:]).astype(int)
             if 'SnapshotPath' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['SnapshotPath'] = line.split()[-1]
             if 'SnapshotFileBase' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['SnapshotFileBase'] = line.split()[-1]
             if 'SnapshotDirBase' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['SnapshotDirBase'] = line.split()[-1]
             if 'SubhaloPath' in line:
-                if(len(line.split()) > 1):
+                if (len(line.split()) > 1):
                     config['SubhaloPath'] = line.split()[-1]
 
     # If we have no SnapshotIdList, this means all snapshots are
@@ -460,8 +460,8 @@ def save(split_dictionary, file_path):
     global_total_splits = comm.allreduce(local_total_splits)
 
     # For completeness purposes, save an empty hdf5 even when we have no splits
-    if(global_total_splits == 0):
-        if(comm_rank == 0):
+    if (global_total_splits == 0):
+        if (comm_rank == 0):
             with h5py.File(file_path, 'w') as file:
                 file.create_dataset("SplitInformation/Keys", data = h5py.Empty("int"))
                 file.create_dataset("SplitInformation/Values", data = h5py.Empty("int"))
@@ -608,9 +608,9 @@ def generate_split_file(path_to_config, snapshot_index, path_to_split_log_files)
     #==========================================================================
     # Check that we are analysing a valid snapshot index
     #==========================================================================
-    if(snapshot_index > config['MaxSnapshotIndex']):
+    if (snapshot_index > config['MaxSnapshotIndex']):
         raise ValueError(f"Chosen snapshot index {snapshot_index} is larger than the one specified in the config ({config['MaxSnapshotIndex']}).")
-    if(snapshot_index < config['MinSnapshotIndex']):
+    if (snapshot_index < config['MinSnapshotIndex']):
         raise ValueError(f"Chosen snapshot index {snapshot_index} is smaller than the one specified in the config ({config['MinSnapshotIndex']}).")
 
     #==========================================================================
@@ -626,7 +626,7 @@ def generate_split_file(path_to_config, snapshot_index, path_to_split_log_files)
     # There will be no splits for snapshot 0, so we can skip its analysis
     #==========================================================================
     if snapshot_index == 0:
-        if(comm_rank == 0):
+        if (comm_rank == 0):
             print(f"Skipping snapshot index {snapshot_index}")
 
         save({},output_file_name)
@@ -656,7 +656,7 @@ def generate_split_file(path_to_config, snapshot_index, path_to_split_log_files)
     # Get how many particles that have been split exist in current snapshot
     total_number_splits = comm.allreduce(len(new_data["counts"]))
 
-    if(total_number_splits) == 0:
+    if total_number_splits == 0:
         if comm_rank == 0:
             print (f"No splits at snapshot index {snapshot_index}. Skipping...")
 

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -7,6 +7,7 @@ comm_size = comm.Get_size()
 
 import os
 import re
+import warnings
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
 import h5py
@@ -90,9 +91,11 @@ def load_overflow_data(path_to_split_log_files):
 
     overflow_data = {}
     for filename in os.listdir(path_to_split_log_files):
-        if not re.match(r'^splits_\d{4}\.hdf5', filename):
+        if not re.match(r'^splits_\d{4}\.txt', filename):
             continue
-        file_data = np.loadtxt(f'{path_to_split_log_files}/{filename}', dtype=np.int64)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            file_data = np.loadtxt(f'{path_to_split_log_files}/{filename}', dtype=np.int64)
         for row in file_data:
             _, new_prog_id, old_prog_id, count, tree = row
             overflow_data[(count, new_prog_id)] = {

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -40,6 +40,8 @@ def load_hbt_config(config_path):
     # i.e. has a value after its name, we store it.
     with open(config_path) as file:
         for line in file:
+            if line[0] == '#':
+                continue
             if 'MinSnapshotIndex' in line:
                 if (len(line.split()) > 1):
                     config['MinSnapshotIndex'] = int(line.split()[-1])

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -268,7 +268,7 @@ def get_corrected_split_trees(split_data, overflow_data):
             # Shift overflow splits
             trees[idx] = trees[idx] << tree_size
             # Add pre-overflow split
-            trees[idx] += overflow_data[key]["tree"]
+            trees[idx] += int(overflow_data[key]["tree"])
         n_overflow -= 1
 
     return progenitor_ids, trees

--- a/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
+++ b/toolbox/swiftsim/particle_splitting/generate_splitting_information.py
@@ -96,6 +96,9 @@ def load_overflow_data(path_to_split_log_files, tree_size):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             file_data = np.loadtxt(f'{path_to_split_log_files}/{filename}', dtype=np.int64)
+            # We need to reshape if there is only one row in the splits file
+            if len(file_data.shape) == 1:
+                file_data = file_data.reshape(1, -1)
         for row in file_data:
             _, new_prog_id, old_prog_id, count, tree = row
             # Handle negative numbers


### PR DESCRIPTION
This PR updates a couple of things relating to the particle splitting script

- [x] Look for .txt files instead of .hdf5, and don't complain if the file is empty
- [x] The original script was written with numpy 1.xx, but numpy 2 was giving an overflow error when trying to add a np.int64 to an array of python ints
- [x] SWIFT outputs negative numbers for progenitor trees. I'm not convinced we're handling this properly