### PR TITLE
Fix pipeline

### DIFF
--- a/toolbox/swiftsim/pipeline/templates/generate_config.sh
+++ b/toolbox/swiftsim/pipeline/templates/generate_config.sh
@@ -29,7 +29,7 @@ HBT_FOLDER=$2
 
 # Parse the SWIFT config file
 if [ ! -f $BASE_PATH/used_parameters.yml ]; then
-   echo "Cannot find used_parameters.yml in $1"
+   echo "Cannot find used_parameters.yml in $BASE_PATH"
 fi
 parameters=($(parse_yaml $BASE_PATH/used_parameters.yml))
 
@@ -53,10 +53,18 @@ do
    fi
 done
 
-# Snapshots are distributed. Each snapshot subfile is contained in its own directory,
-# which has the same base name.
+# Snapshots are, in principle, distributed. Each snapshot subfile is contained in its own directory,
+# which has the same base name as the snapshot.
 if [ $SNAPSHOTS_ARE_DISTRIBUTED == 1 ] ; then
-      SNAPSHOT_BASEDIR=$SNAPSHOT_BASENAME
+
+   SNAPSHOT_BASEDIR=$SNAPSHOT_BASENAME
+
+   # We do this check because runs where SNAPSHOTS_ARE_DISTRIBUTED == 1 can still just use a single
+   # file per snapshot (if one MPI rank was used).
+   NUMBER_SUBDIR=$(find $BASE_PATH -maxdepth 1 -name "${SNAPSHOT_BASEDIR}_????" | wc -l)
+   if [ $NUMBER_SUBDIR -eq 0 ]; then
+      SNAPSHOT_BASEDIR=""
+   fi
 else
    $SNAPSHOT_BASEDIR=""
 fi

--- a/toolbox/swiftsim/pipeline/templates/generate_config.sh
+++ b/toolbox/swiftsim/pipeline/templates/generate_config.sh
@@ -56,15 +56,7 @@ done
 # Snapshots are, in principle, distributed. Each snapshot subfile is contained in its own directory,
 # which has the same base name as the snapshot.
 if [ $SNAPSHOTS_ARE_DISTRIBUTED == 1 ] ; then
-
    SNAPSHOT_BASEDIR=$SNAPSHOT_BASENAME
-
-   # We do this check because runs where SNAPSHOTS_ARE_DISTRIBUTED == 1 can still just use a single
-   # file per snapshot (if one MPI rank was used).
-   NUMBER_SUBDIR=$(find $BASE_PATH -maxdepth 1 -name "${SNAPSHOT_BASEDIR}_????" | wc -l)
-   if [ $NUMBER_SUBDIR -eq 0 ]; then
-      SNAPSHOT_BASEDIR=""
-   fi
 else
    $SNAPSHOT_BASEDIR=""
 fi
@@ -79,6 +71,15 @@ if [ $SNAPSHOT_DIRECTORY == "." ]; then
    # parameter file option
    if [ -d $BASE_PATH/snapshots ]; then
       SNAPSHOT_DIRECTORY="snapshots"
+   fi
+fi
+
+# Snapshots that should be distributed are not, if one MPI rank was used. We defer this correction
+# to be done here since we first needed to set SNAPSHOT_DIRECTORY
+if [ $SNAPSHOTS_ARE_DISTRIBUTED == 1 ] ; then
+   NUMBER_SUBDIR=$(find $BASE_PATH/$SNAPSHOT_DIRECTORY -maxdepth 1 -name "${SNAPSHOT_BASEDIR}_????" | wc -l)
+   if [ $NUMBER_SUBDIR -eq 0 ]; then
+      SNAPSHOT_BASEDIR=""
    fi
 fi
 


### PR DESCRIPTION
This fixes the automatic configuration generator for COLIBRE, as it did not work for SWIFT runs that use a single MPI rank and have distributed snapshots enabled in the used_parameters.txt.

I have tested that it works for all three ways that we (annoyingly) use at the moment: 

1. Snapshots are split in subfiles and in the base folder
2. Snapshots are split in subfiles and are saved in a snapshots folder
3. Snapshots should be split in subfiles but are not because we use a single MPI rank.

I have not explicitly tested a final combination of points 2 and 3,  since we thankfully do not have 4 ways of saving data. However, I think my implementation can handle this hypothetical setup.