### PR TITLE
Identify subhalo-subhalo mergers and update the nesting hierarchy

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -102,6 +102,13 @@ int main(int argc, char **argv)
     // Don't need the particle data after this point, so save memory
     partsnap.ClearParticles();
 
+    // In order to determine how subhalos are nested we need a position and
+    // radius for each one. We can use the half mass radius from the previous
+    // snapshot, but we need to evaluate the new position now before we modify
+    // the subhalo membership in CleanTracks().
+    for(auto subhalo : subsnap.Subhalos)
+      subhalo.AverageCoordinates();
+
     /* Clean up the source subhaloes from duplicate particles originating from the
      * previous snapshot. We need to do it here so that any removed bound particles
      * contribute to the estimate of the subgroup CoM position and velocity (used in

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -74,6 +74,8 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(MaxPhysicalSofteningHalo);
   TrySetPar(TracerParticleBitMask);
   TrySetPar(ParticlesSplit);
+  TrySetPar(SymmetricMerging);
+  TrySetPar(SpatialNesting);
 
 #undef TrySetPar
 
@@ -324,6 +326,8 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncBool(GroupLoadedFullParticle);
   _SyncAtom(TracerParticleBitMask, MPI_INT);
   _SyncAtom(ParticlesSplit, MPI_INT);
+  _SyncBool(SymmetricMerging);
+  _SyncBool(SpatialNesting);
   //---------------end sync params-------------------------//
 
   _SyncReal(PhysicalConst::G);
@@ -446,6 +450,8 @@ void Parameter_t::DumpParameters()
   }
   DumpPar(MergeTrappedSubhalos);
   DumpPar(MajorProgenitorMassRatio);
+  DumpPar(SymmetricMerging);
+  DumpPar(SpatialNesting);
 
 #undef DumpPar
 #undef DumpHeader

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -81,6 +81,9 @@ public:
   int TracerParticleBitMask; /* Bitmask used to identify which particle type can be used as tracer */
   int ParticlesSplit;        /* Whether baryonic particles are able to split. Relevant to swift simulations */
 
+  bool SymmetricMerging; // Also merge subhalos if they satisfy the merging criterion with host and subhalo reversed
+  bool SpatialNesting;   // Try to detect spatially nested subhalos which have not been linked by HBT
+
   /*derived parameters; do not require user input*/
   HBTReal TreeNodeOpenAngleSquare;
   HBTReal TreeNodeResolution;
@@ -140,6 +143,11 @@ public:
      * we will default to a value of 1 if this is a swift HYDRO run. This way we reminder the
      * user to pre-process snapshots (toolbox/swiftsim/generate_splitting_information.py) */
     ParticlesSplit = -1;
+
+    /* Modifications to subhalo nesting and merging */
+    SymmetricMerging = true;
+    SpatialNesting = true;
+
   }
   void ReadSnapshotNameList();
   void ParseConfigFile(const char *param_file);

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -82,7 +82,8 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   InsertMember(SinkTrackId, H5T_HBTInt);
   InsertMember(DescendantTrackId, H5T_HBTInt);
   InsertMember(NestedParentTrackId, H5T_HBTInt);
-  InsertMember(NewParentTrackId, H5T_HBTInt);
+  InsertMember(SpatialNestingTrackId, H5T_HBTInt);
+  InsertMember(SnapshotIndexOfSpatialNesting, H5T_HBTInt);
 #undef InsertMember
   H5T_SubhaloInDisk = H5Tcopy(H5T_SubhaloInMem);
   H5Tpack(H5T_SubhaloInDisk); // clear fields not added.

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -82,6 +82,7 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   InsertMember(SinkTrackId, H5T_HBTInt);
   InsertMember(DescendantTrackId, H5T_HBTInt);
   InsertMember(NestedParentTrackId, H5T_HBTInt);
+  InsertMember(NewParentTrackId, H5T_HBTInt);
 #undef InsertMember
   H5T_SubhaloInDisk = H5Tcopy(H5T_SubhaloInMem);
   H5Tpack(H5T_SubhaloInDisk); // clear fields not added.

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -192,7 +192,9 @@ void SubhaloSnapshot_t::BuildMPIDataType()
   RegisterAttr(SinkTrackId, MPI_HBT_INT, 1);
   RegisterAttr(DescendantTrackId, MPI_HBT_INT, 1);
   RegisterAttr(NestedParentTrackId, MPI_HBT_INT, 1);
-  RegisterAttr(NewParentTrackId, MPI_HBT_INT, 1);
+  RegisterAttr(SpatialNestingTrackId, MPI_HBT_INT, 1);
+  RegisterAttr(SnapshotIndexOfSpatialNesting, MPI_HBT_INT, 1);
+
 #undef RegisterAttr
   assert(NumAttr <= MaxNumAttr);
 

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -192,6 +192,7 @@ void SubhaloSnapshot_t::BuildMPIDataType()
   RegisterAttr(SinkTrackId, MPI_HBT_INT, 1);
   RegisterAttr(DescendantTrackId, MPI_HBT_INT, 1);
   RegisterAttr(NestedParentTrackId, MPI_HBT_INT, 1);
+  RegisterAttr(NewParentTrackId, MPI_HBT_INT, 1);
 #undef RegisterAttr
   assert(NumAttr <= MaxNumAttr);
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -325,8 +325,8 @@ public:
   void PrepareCentrals(MpiWorker_t &world, HaloSnapshot_t &halo_snap);
   void RefineParticles();
   void UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
-  void IdentifyNewlyNestedSubhalos(const HaloSnapshot_t &halo_snap);
-  
+  void IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
+
   /* To remove duplicate particles from the source subgroup. */
   void CleanTracks();
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -274,7 +274,7 @@ private:
   void ExtendCentralNest();
   void LocalizeNestedIds(MpiWorker_t &world);
   void GlobalizeTrackReferences();
-  void NestSubhalos(MpiWorker_t &world);
+  void NestSubhalos(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
   void MaskSubhalos();
   vector<int> RootNestSize; // buffer variable for temporary use.
   void FillDepthRecursive(HBTInt subid, int depth);

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -94,6 +94,7 @@ public:
   HBTInt DescendantTrackId;   // the trackId containing a subset of the particles most bound to this object in the
                               // previous output
   HBTInt NestedParentTrackId; // the trackID of the subhalo containing this subhalo, or -1 for top level subhalos
+  HBTInt NewParentTrackId; // the trackID of the subhalo spatially containing this subhalo if not already identified from merger history
 
   ParticleList_t Particles;
 
@@ -136,6 +137,7 @@ public:
     DescendantTrackId = SpecialConst::NullTrackId;
     MostBoundParticleId = SpecialConst::NullParticleId;
     TracerIndex = -1;
+    NewParentTrackId = -1;
   }
   void Unbind(const Snapshot_t &epoch);
   void RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap);

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -323,7 +323,8 @@ public:
   void PrepareCentrals(MpiWorker_t &world, HaloSnapshot_t &halo_snap);
   void RefineParticles();
   void UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &halo_snap);
-
+  void IdentifyNewlyNestedSubhalos(const HaloSnapshot_t &halo_snap);
+  
   /* To remove duplicate particles from the source subgroup. */
   void CleanTracks();
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -94,7 +94,8 @@ public:
   HBTInt DescendantTrackId;   // the trackId containing a subset of the particles most bound to this object in the
                               // previous output
   HBTInt NestedParentTrackId; // the trackID of the subhalo containing this subhalo, or -1 for top level subhalos
-  HBTInt NewParentTrackId; // the trackID of the subhalo spatially containing this subhalo if not already identified from merger history
+  HBTInt SpatialNestingTrackId; // the trackID of the subhalo spatially containing this subhalo if not already identified from merger history
+  HBTInt SnapshotIndexOfSpatialNesting; // the last snapshot at which the nesting of this subhalo was modified
 
   ParticleList_t Particles;
 
@@ -137,7 +138,8 @@ public:
     DescendantTrackId = SpecialConst::NullTrackId;
     MostBoundParticleId = SpecialConst::NullParticleId;
     TracerIndex = -1;
-    NewParentTrackId = -1;
+    SpatialNestingTrackId = -1;
+    SnapshotIndexOfSpatialNesting = -1;
   }
   void Unbind(const Snapshot_t &epoch);
   void RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap);

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -7,6 +7,7 @@
 #include "datatypes.h"
 #include "snapshot_number.h"
 #include "subhalo.h"
+#include "config_parser.h"
 
 #define NumPartCoreMax 20
 #define PhaseSpaceDistanceThreshold 2.
@@ -19,13 +20,15 @@ float Subhalo_t::PhaseSpaceDistance(const Subhalo_t &ReferenceSubhalo)
   float velocity_offset = Distance(ReferenceSubhalo.CorePhysicalVelocity, CorePhysicalVelocity);
   float distance = position_offset / ReferenceSubhalo.CoreComovingSigmaR + velocity_offset / ReferenceSubhalo.CorePhysicalSigmaV;
 
-  // Force the merging criterion to be symmetric where possible. Here we
-  // compute the distance if we reverse this subhalo and the reference subhalo
-  // and use the smaller value to decide if we have a merger. Orphans don't
-  // have a dispersion so can't be handled this way.
-  if(Nbound > 1) {
-    float reverse_distance = position_offset / CoreComovingSigmaR + velocity_offset / CorePhysicalSigmaV;
-    distance = std::min(distance, reverse_distance);
+  if(HBTConfig.SymmetricMerging) {
+    // Force the merging criterion to be symmetric where possible. Here we
+    // compute the distance if we reverse this subhalo and the reference subhalo
+    // and use the smaller value to decide if we have a merger. Orphans don't
+    // have a dispersion so can't be handled this way.
+    if(Nbound > 1) {
+      float reverse_distance = position_offset / CoreComovingSigmaR + velocity_offset / CorePhysicalSigmaV;
+      distance = std::min(distance, reverse_distance);
+    }
   }
   return distance;
 }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1537,10 +1537,16 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const Ha
           // be a subhalo of new_parent without preventing any merger checks.
           bool can_reassign = false;
           if(parent_index[child_index] < 0) {
-            // Child subhalo has no parent so we're free to reassign it
+            // Child subhalo has no parent, so we're free to reassign it a
+            // new parent.
+            can_reassign = true;
+          } else if(parent_index[child_index] == ordered_list[0]) {
+            // Child subhalo's parent is the central, which is the parent of
+            // everything else so we're free to reassign a new parent.
             can_reassign = true;
           } else {
-            // Check that new parent is somewhere nested within the old parent
+            // Child subhalo's parent is a subhalo. Check that the new parent
+            // we're going to assign is somewhere nested within the parent
             HBTInt parent_of_new_parent = new_parent_index;
             while(parent_of_new_parent >= 0) {
               if(parent_of_new_parent == parent_index[child_index])can_reassign = true;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1555,6 +1555,7 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const Ha
             parent_index[child_index] = new_parent_index;
             child.Rank = child_rank; // Must have Rank>0 if we have a parent subhalo
             nr_modified += 1;
+            reassigned = true;
           }
         }
         // If we renested this subhalo, don't need to check for any more possible parents

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1500,6 +1500,10 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const Ha
         // Child subhalo should be no more massive than the parent
         assert(child.Mbound <= new_parent.Mbound);
 
+        // Don't consider orphan subhalos as possible parents, because they
+        // don't have an associated radius
+        if(new_parent.Nbound <= 1)continue;
+
         // Check that we don't already have any hierarchical relation between
         // the two subhalos in either direction. If new_parent is already a
         // parent of child there's nothing to do.

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1400,8 +1400,8 @@ void SubhaloSnapshot_t::UpdateTracks(MpiWorker_t &world, const HaloSnapshot_t &h
         Subhalos[i].HostHaloId = halo_snap.Halos[HostId].HaloId; // restore global haloid
     }
     GlobalizeTrackReferences();
-    SetNestedParentIds();
   }
+  SetNestedParentIds();
 #pragma omp parallel for if (ParallelizeHaloes)
   for (HBTInt i = 0; i < Subhalos.size(); i++)
   {

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1480,19 +1480,19 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const Ha
     // Loop over subhalos in the halo in ascending order of mass, excluding
     // the main subhalo because anything not already nested will be added to
     // the main subhalo by ExtendCentralNests() anyway.
-    for(HBTInt i=nr_subhalos-1; i>0; i-=1) {
+    for(HBTInt child_rank=nr_subhalos-1; child_rank>0; child_rank-=1) {
 
       // We're going to check if this subhalo should be nested in any of the
       // more massive subhalos other than the central. First, get a reference
       // to the subhalo we're considering re-nesting.
-      HBTInt child_index = ordered_list[i];
-      Subhalo_t &child = Subhalos[ordered_list[i]];
+      HBTInt child_index = ordered_list[child_rank];
+      Subhalo_t &child = Subhalos[ordered_list[child_rank]];
 
       // Then, loop over possible new parent subhalos - i.e. all more massive subhalos
-      for(HBTInt j=i-1; j>0; j-=1) {
+      for(HBTInt new_parent_rank=child_rank-1; new_parent_rank>0; new_parent_rank-=1) {
 
         // Get a reference to the possible new parent
-        HBTInt new_parent_index = ordered_list[j];
+        HBTInt new_parent_index = ordered_list[new_parent_rank];
         Subhalo_t &new_parent = Subhalos[new_parent_index];
 
         // Subhalos should be in the same host halo
@@ -1553,7 +1553,7 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const Ha
             child.SpatialNestingTrackId = new_parent.TrackId;
             child.SnapshotIndexOfSpatialNesting = GetSnapshotIndex();
             parent_index[child_index] = new_parent_index;
-            child.Rank = i; // Must have Rank>0 if we have a parent subhalo
+            child.Rank = child_rank; // Must have Rank>0 if we have a parent subhalo
             nr_modified += 1;
           }
         }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1450,6 +1450,7 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(const HaloSnapshot_t &halo_s
       assert(j < parent_index.size()); // NestedSubhalos should contain local subhalo array indexes
       assert(Subhalos[j].HostHaloId==Subhalos[i].HostHaloId); // Subhalos not in the same FoF should have been removed from nests
       assert(Subhalos[j].Rank != 0); // Subhalos with Rank=0 should not be nested
+      assert(parent_index[j] == -1); // Subhalos can only have one parent
       parent_index[j] = i;
     }
   }
@@ -1554,7 +1555,7 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(const HaloSnapshot_t &halo_s
   } // Next FoF halo
 
   // Now reconstruct the nests. First clear all nest arrays.
-  for(auto subhalo : Subhalos) {
+  for(auto &subhalo : Subhalos) {
     subhalo.NestedSubhalos.clear();
   }
 

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1548,7 +1548,8 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(MpiWorker_t &world, const Ha
           if(can_reassign) {
             // Child subhalo can be assigned a new parent.
             assert(child.TrackId != new_parent.TrackId);
-            child.NewParentTrackId = new_parent.TrackId;
+            child.SpatialNestingTrackId = new_parent.TrackId;
+            child.SnapshotIndexOfSpatialNesting = GetSnapshotIndex();
             parent_index[child_index] = new_parent_index;
             child.Rank = j; // Must have Rank>0 if we have a parent subhalo
             nr_modified += 1;

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1480,17 +1480,30 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(const HaloSnapshot_t &halo_s
         // Child subhalo should be less massive than the parent
         assert(child.Mbound <= new_parent.Mbound);
 
-        // Check that the child is not already a subhalo (or sub-sub,
-        // sub-sub-sub halo etc) of the possible new parent.
-        bool is_subhalo = false;
-        HBTInt parent_of_child = child_index;
-        while(parent_of_child >= 0) {
-          if(parent_of_child == new_parent_index)is_subhalo = true;
-          parent_of_child = parent_index[parent_of_child];
+        // Check that we don't already have any hierarchical relation between
+        // the two subhalos in either direction. If new_parent is already a
+        // parent of child there's nothing to do.
+        bool connected = false;
+        HBTInt sub_index = child_index;
+        while(sub_index >= 0) {
+          if(sub_index == new_parent_index){
+            connected = true;
+            break;
+          }
+          sub_index = parent_index[sub_index];
         }
-        if(is_subhalo)continue;
+        // Don't try to nest a subhalo inside itself or any of its sub-subhalos etc
+        sub_index = new_parent_index;
+        while(sub_index >= 0) {
+          if(sub_index == child_index) {
+            connected = true;
+            break;
+          }
+          sub_index = parent_index[sub_index];
+        }
+        if(connected)continue;
 
-        // Check if child subhalo is enclosed by parent subhalo
+        // Check if child subhalo is enclosed by possible new parent subhalo
         HBTxyz new_parent_pos = new_parent.ComovingMostBoundPosition;
         HBTReal new_parent_radius = 2*new_parent.RHalfComoving;
         assert(new_parent_radius > 0.0);

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1528,14 +1528,25 @@ void SubhaloSnapshot_t::IdentifyNewlyNestedSubhalos(const HaloSnapshot_t &halo_s
           }
           if(can_reassign) {
             // Child subhalo can be assigned a new parent.
-            // For now we'll just record the parent TrackId without modifying the nesting
             assert(child.TrackId != new_parent.TrackId);
             child.NewParentTrackId = new_parent.TrackId;
+            parent_index[child_index] = new_parent_index;
           }
         }
       } // Next possible child halo
     } // Next possible parent halo
   } // Next FoF halo
 
-  // TODO: Reconstruct nesting arrays
+  // Now reconstruct the nests for subhalos in this FoF group.
+  // First clear all nest arrays.
+  for(auto subhalo : Subhalos) {
+    subhalo.NestedSubhalos.clear();
+  }
+
+  // Then add all nested subhalos back to the nest arrays
+  for(HBTInt i=0; i<Subhalos.size(); i+=1) {
+    if(parent_index[i] >= 0) {
+      Subhalos[parent_index[i]].NestedSubhalos.push_back(i);
+    }
+  }
 }

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -1005,7 +1005,7 @@ void SubhaloSnapshot_t::NestSubhalos(MpiWorker_t &world, const HaloSnapshot_t &h
   /* Update subhalo nesting where necessary. This will identify cases where a
      subhalo is within the spatial extent of another subhalo but has not been
      identified as a sub-subhalo. */
-  IdentifyNewlyNestedSubhalos(world, halo_snap);
+  if(HBTConfig.SpatialNesting)IdentifyNewlyNestedSubhalos(world, halo_snap);
 
 // collect detached(head) subhalos
 #pragma omp single

--- a/testing/subhalo_mergers/colibre_L0050N0376.sh
+++ b/testing/subhalo_mergers/colibre_L0050N0376.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -l
+#
+#SBATCH --tasks=64
+#SBATCH --cpus-per-task=1
+#SBATCH -J colibre
+#SBATCH -o ./logs/%x_%A.%a.out
+#SBATCH -p cosma8-shm2
+#SBATCH -A dp004
+#SBATCH -t 2:00:00
+#
+
+module purge
+module load gnu_comp/14.1.0 openmpi
+activate failed_mergers
+
+snap_nr=`printf '%03d' ${SLURM_ARRAY_TASK_ID}`
+branch="master"
+
+# Compute core position and extent in phase space
+mpirun -- python3 -m mpi4py merging_condition.py \
+       "/cosma8/data/dp004/colibre/Runs/L0050N0376/Thermal_non_equilibrium/snapshots/colibre_{snap_nr:04d}/colibre_{snap_nr:04d}.{file_nr}.hdf5" \
+       "/cosma8/data/dp004/jch/failed_mergers/COLIBRE/L0050N0376/Thermal_non_equilibrium/${branch}/membership/membership_{snap_nr:04d}/membership_{snap_nr:04d}.{file_nr}.hdf5" \
+       "/cosma8/data/dp004/jch/failed_mergers/COLIBRE/L0050N0376/Thermal_non_equilibrium/${branch}/output/" \
+       "/cosma8/data/dp004/jch/failed_mergers/COLIBRE/L0050N0376/Thermal_non_equilibrium/${branch}/failed_mergers/" \
+       ${snap_nr}
+
+# Identify things which should have merged but did not
+python3 ./find_unmerged.py \
+        "/cosma8/data/dp004/jch/failed_mergers/COLIBRE/L0050N0376/Thermal_non_equilibrium/${branch}/failed_mergers/merging_info_${snap_nr}.hdf5" \
+        "/cosma8/data/dp004/jch/failed_mergers/COLIBRE/L0050N0376/Thermal_non_equilibrium/${branch}/failed_mergers/failed_mergers_${snap_nr}.hdf5"
+
+# Make plots
+python3 ./plot_failed_mergers.py ${snap_nr} ${branch}

--- a/testing/subhalo_mergers/find_unmerged.py
+++ b/testing/subhalo_mergers/find_unmerged.py
@@ -1,0 +1,116 @@
+#!/bin/env python
+
+import sys
+
+import numpy as np
+import h5py
+
+
+def periodic_distance(pos1, pos2, boxsize):
+    dx = pos2 - pos1
+    dx[dx >  0.5*boxsize] -= boxsize
+    dx[dx < -0.5*boxsize] += boxsize
+    return np.sqrt(np.sum(dx**2, axis=-1))
+
+
+def distance(pos1, pos2, boxsize):
+    dx = pos2 - pos1
+    return np.sqrt(np.sum(dx**2, axis=-1))
+
+
+def find_unmerged(input_filename, output_filename):
+
+    # Read in the input catalogue
+    with h5py.File(input_filename, "r") as f:
+        pos = f["CoreComovingPosition"][...]
+        sigma_r = f["CoreComovingSigmaR"][...]
+        vel = f["CorePhysicalVelocity"][...]
+        sigma_v = f["CorePhysicalSigmaV"][...]
+        nbound = f["Nbound"][...]
+        boxsize = f["BoxSize"][()]
+        trackid = f["TrackId"][...]
+        parent_trackid = f["NestedParentTrackId"][...]
+
+    # Build a kdtree from the halo positions
+    from scipy.spatial import KDTree
+    tree = KDTree(pos, boxsize=boxsize)
+
+    # This will flag any subhalos which should have merged
+    failed_merger = np.zeros(len(nbound), dtype=int)
+    failed_merger_idx = -np.ones(len(nbound), dtype=int)
+    r_sep = -np.ones(len(nbound), dtype=float)
+    v_sep = -np.ones(len(nbound), dtype=float)
+    r_sep_parent = -np.ones(len(nbound), dtype=float)
+    v_sep_parent = -np.ones(len(nbound), dtype=float)
+
+    # Identify the parent halo for each subhalo, where there is one
+    import virgo.util.match as m
+    parent_index = m.match(parent_trackid, trackid) # will be -1 for top level halos
+
+    min_nbound = 20
+    radius_factor = 2.0
+
+    # Loop over subhalos
+    for i in range(len(nbound)):
+
+        if nbound[i] < min_nbound:
+            continue
+        
+        # Locate all other subhalos within 2*sigma_r
+        max_radius = radius_factor*sigma_r[i]
+        ngb_idx = np.asarray(tree.query_ball_point(pos[i,:], max_radius), dtype=int)
+
+        # Remove self and any unresolved neighbours from the list
+        keep = (ngb_idx != i) & (nbound[ngb_idx] >= min_nbound)
+        ngb_idx = ngb_idx[keep]
+    
+        if len(ngb_idx) > 0:
+            
+            # Get normalized phase space distance
+            pos_dist = periodic_distance(pos[i,:], pos[ngb_idx,:], boxsize) / sigma_r[i]
+            vel_dist = distance(vel[i,:], vel[ngb_idx,:], boxsize) / sigma_v[i]
+
+            # Identify any with velocity difference less than 2*sigma_v
+            merged = pos_dist+vel_dist < radius_factor
+
+            # Tag failed mergers: if we satsify the merging condition, the neighbour should have merged
+            failed_merger[ngb_idx[merged]] = 1
+            failed_merger_idx[ngb_idx[merged]] = i
+
+            # Record separation for problem objects
+            r_sep[ngb_idx[merged]] = pos_dist[merged]
+            v_sep[ngb_idx[merged]] = vel_dist[merged]
+
+            # Loop over neighbours j which should have merged onto subhalo i but didn't
+            for j in ngb_idx[merged]:
+
+                print(f"Subhalo with TrackId={trackid[j]} should have merged to TrackId={trackid[i]} but didn't")
+                
+                # Check if any of subhalo j's parent subhalos are subhalo i
+                k = parent_index[j]
+                while k >= 0:
+                    print(f"  Parent has TrackId={trackid[k]}")
+                    if k == i:
+                        failed_merger[j] = 2 # Failed merger despite being in the subhalo hierarchy
+                    k = parent_index[k]
+
+        # Get normalized phase space distance to immediate parent halo, if any
+        if parent_index[i] >= 0 and nbound[parent_index[i]] > min_nbound:
+            r_sep_parent[i] = periodic_distance(pos[i,:], pos[parent_index[i],:], boxsize) / sigma_r[parent_index[i]]
+            v_sep_parent[i] = distance(vel[i,:], vel[parent_index[i],:], boxsize) / sigma_v[parent_index[i]]
+                    
+    # Write out the result
+    with h5py.File(output_filename, "w") as outfile:
+        outfile["failed_merger"] = failed_merger
+        outfile["failed_merger_idx"] = failed_merger_idx
+        outfile["r_sep"] = r_sep
+        outfile["v_sep"] = v_sep
+        outfile["r_sep_parent"] = r_sep_parent
+        outfile["v_sep_parent"] = v_sep_parent
+
+if __name__ == "__main__":
+
+    input_filename = sys.argv[1]
+    output_filename = sys.argv[2]
+    
+    find_unmerged(input_filename, output_filename)

--- a/testing/subhalo_mergers/merging_condition.py
+++ b/testing/subhalo_mergers/merging_condition.py
@@ -1,0 +1,382 @@
+#!/bin/env python
+#
+# Compute quantities used to determine subhalo mergers in HBTplus
+#
+
+import os
+import os.path
+
+import numpy as np
+import h5py
+import unyt
+
+import virgo.mpi.parallel_hdf5 as phdf5
+import virgo.mpi.parallel_sort as psort
+import virgo.util.partial_formatter as pf
+import virgo.formats.swift
+
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+comm_size = comm.Get_size()
+
+nr_tracers = 20
+tracer_types = (1, 4)
+#tracer_types = (1,)
+
+
+def destination_rank(arr, comm_size):
+    """
+    Assign elements of integer array arr to MPI ranks.
+    """
+    if arr.dtype.itemsize == 4:
+        arr_view = arr.view(dtype=np.uint32)
+        arr_hash = np.bitwise_xor(np.right_shift(arr_view, 16), arr_view)
+        arr_hash *= 0x45d9f3b
+        arr_hash = np.bitwise_xor(np.right_shift(arr_hash, 16), arr_hash)
+        arr_hash *= 0x45d9f3b
+        arr_hash = np.bitwise_xor(np.right_shift(arr_hash, 16), arr_hash)
+    elif arr.dtype.itemsize == 8:
+        arr_view = arr.view(dtype=np.uint64)
+        arr_hash = np.bitwise_xor(arr_view, np.right_shift(arr_view, 30))
+        arr_hash *= 0xbf58476d1ce4e5b9
+        arr_hash = np.bitwise_xor(arr_hash, np.right_shift(arr_hash, 27))
+        arr_hash *= 0x94d049bb133111eb
+        arr_hash = np.bitwise_xor(arr_hash, np.right_shift(arr_hash, 31))
+    else:
+        raise RuntimeError("Unsupported data type: must be 4 or 8 bytes per element")
+    return np.mod(arr_hash, comm_size).astype(int)
+
+
+def message(s):
+    if comm_rank == 0:
+        print(s)
+
+
+def read_snapshot(snapshot_format, membership_format, snap_nr):
+    """
+    Read particle data from the snapshot and membership files.
+    
+    Here we need position, velocity, bound rank and group number.
+    Need to read and concatenate data from all particle types.
+    """
+
+    # First need to determine number of snapshot files
+    if comm_rank == 0:
+        filename = snapshot_format.format(file_nr=0, snap_nr=snap_nr)
+        with h5py.File(filename, "r") as infile:
+            nr_files = infile["Header"].attrs["NumFilesPerSnapshot"][0]
+    else:
+        nr_files = None
+    nr_files = comm.bcast(nr_files)
+    
+    # Read the snapshot files
+    formatter = pf.PartialFormatter()
+    snap_filename = formatter.format(snapshot_format, snap_nr=snap_nr, file_nr=None)
+    snap = phdf5.MultiFile(snap_filename, file_idx=np.arange(nr_files, dtype=int), comm=comm)
+    pos = []
+    vel = []
+    mass = []
+    ptype = []
+    for type_nr in tracer_types:
+        data = snap.read(("Coordinates", "Velocities", "Masses"), group=f"PartType{type_nr}", unpack=True)
+        pos.append(data[0])
+        vel.append(data[1])
+        mass.append(data[2])
+        ptype.append(np.ones(pos[-1].shape[0], dtype=np.int32) * type_nr)
+
+    # Read the membership files
+    memb_filename = formatter.format(membership_format, snap_nr=snap_nr, file_nr=None)
+    memb = phdf5.MultiFile(memb_filename, file_idx=np.arange(nr_files, dtype=int), comm=comm)
+    bound_rank = []
+    groupnr_bound = []
+    for type_nr in tracer_types:
+        data = memb.read(("GroupNr_bound", "Rank_bound"), group=f"PartType{type_nr}", unpack=True)
+        groupnr_bound.append(data[0])
+        bound_rank.append(data[1])
+    
+    # Combine arrays
+    pos = np.concatenate(pos)
+    vel = np.concatenate(vel)
+    mass = np.concatenate(mass)
+    ptype = np.concatenate(ptype)
+    groupnr_bound = np.concatenate(groupnr_bound)
+    bound_rank = np.concatenate(bound_rank)
+
+    # Discard particles not bound to any halo
+    keep = (bound_rank >= 0)
+    pos = pos[keep,:]
+    vel = vel[keep,:]
+    mass = mass[keep]
+    ptype = ptype[keep]
+    groupnr_bound = groupnr_bound[keep]
+    bound_rank = bound_rank[keep]
+
+    return pos, vel, mass, groupnr_bound, bound_rank, ptype
+
+
+def read_hbt(hbt_basedir, snap_nr):
+    """
+    Read the HBT halo catalogue
+    """
+
+    hbt_filename = hbt_basedir + f"/{snap_nr:03d}/SubSnap_{snap_nr:03d}" + ".{file_nr}.hdf5"
+    mf = phdf5.MultiFile(hbt_filename, file_nr_dataset="NumberOfFiles", comm=comm)
+    subhalos = mf.read("Subhalos")
+    return subhalos
+    
+
+def compute_merging_condition(snapshot_format, membership_format, hbt_basedir, output_dir, snap_nr):
+    """
+    Compute position and radius for each subhalo in phase space
+    """
+
+    # Read box size and units
+    length_in_mpch = None
+    vel_in_kms = None
+    mass_in_msunh = None
+    if comm_rank == 0:
+        filename = f"{hbt_basedir}/Parameters.log"
+        with open(filename) as f:
+            for line in f:
+                fields = line.rstrip().split()
+                if len(fields) < 2:
+                    continue
+                if fields[0] == "LengthInMpch":
+                    length_in_mpch = float(fields[1])
+                if fields[0] == "VelInKmS":
+                    vel_in_kms = float(fields[1])
+                if fields[0] == "MassInMsunh":
+                    mass_in_msunh = float(fields[1])
+    length_in_mpch, vel_in_kms, mass_in_msunh = comm.bcast((length_in_mpch, vel_in_kms, mass_in_msunh))
+
+    # Set up swift unit registry by reading a snapshot file
+    reg = None
+    boxsize = None
+    if comm_rank == 0:
+        filename = snapshot_format.format(file_nr=0, snap_nr=snap_nr)
+        with h5py.File(filename, "r") as snap:
+            reg = virgo.formats.swift.soap_unit_registry_from_snapshot(snap)
+            boxsize = snap["Header"].attrs["BoxSize"][0]
+    reg, boxsize = comm.bcast((reg, boxsize))
+    #boxsize = boxsize * unyt.Unit("snap_length", registry=reg) # Get box size with units
+    message(f"Box size = {boxsize}")
+
+    # Determine HBT units using Swift's Mpc and Msun definitions
+    hbt_length   = length_in_mpch*unyt.Unit("a*swift_mpc/h", registry=reg)
+    hbt_velocity = vel_in_kms*unyt.Unit("km/s", registry=reg)
+    hbt_mass     = mass_in_msunh*unyt.Unit("swift_msun/h", registry=reg)
+    message(f"HBT length unit = {hbt_length}")
+    message(f"HBT velocity unit = {hbt_velocity}")
+    message(f"HBT mass unit = {hbt_mass}")
+    
+    # Read in the HBT catalogue
+    subhalos = read_hbt(hbt_basedir, snap_nr)
+    nr_subs = len(subhalos)
+    nr_subs_tot = comm.allreduce(nr_subs)
+    message(f"Total number of subhalos read = {nr_subs_tot}")
+    
+    # Assign HBT halos to MPI ranks according to hash of their index
+    nr_local_subhalos = len(subhalos)
+    local_subhalo_offset = comm.scan(nr_local_subhalos) - nr_local_subhalos
+    subhalo_groupnr = np.arange(nr_local_subhalos, dtype=int) + local_subhalo_offset
+    subhalo_rank = destination_rank(subhalo_groupnr, comm_size)
+    message("Assigned destination ranks to subhalos")
+    
+    # Sort HBT halos by destination rank
+    sort_key = subhalo_rank.copy()
+    order = psort.parallel_sort(sort_key, return_index=True, comm=comm)
+    subhalos = psort.fetch_elements(subhalos, order, comm=comm)
+    subhalo_groupnr = psort.fetch_elements(subhalo_groupnr, order, comm=comm)
+    subhalo_rank = psort.fetch_elements(subhalo_rank, order, comm=comm)
+    message("Sorted subhalos")
+    
+    # Count subhalos to go to each rank
+    nr_per_rank = np.bincount(subhalo_rank, minlength=comm_size)
+    comm.Allreduce(MPI.IN_PLACE, nr_per_rank)
+    nr_total_subhalos = comm.allreduce(nr_local_subhalos)
+    assert np.sum(nr_per_rank) == nr_total_subhalos
+    message("Counted subhalos per rank")
+
+    # Repartition subhalos. After this they should all be on the assigned MPI rank.
+    subhalos = psort.repartition(subhalos, ndesired=nr_per_rank, comm=comm)
+    subhalo_groupnr = psort.repartition(subhalo_groupnr, ndesired=nr_per_rank, comm=comm)
+    subhalo_rank = psort.repartition(subhalo_rank, ndesired=nr_per_rank, comm=comm)
+    assert np.all(subhalo_rank==comm_rank)
+    del subhalo_rank
+    message("Repartitioned subhalos")
+    
+    # Read in the bound particles
+    pos, vel, mass, groupnr_bound, bound_rank, ptype = read_snapshot(snapshot_format, membership_format, snap_nr)
+    nr_parts = pos.shape[0]
+    nr_parts_tot = comm.allreduce(nr_parts)
+    message(f"Total number of particles read = {nr_parts_tot}")
+
+    # Assign particles to MPI rank according to hash of their group index
+    particle_rank = destination_rank(groupnr_bound, comm_size)
+    
+    # Sort particles by destination rank
+    order = psort.parallel_sort(particle_rank, return_index=True, comm=comm)
+    pos = psort.fetch_elements(pos, order, comm=comm)
+    vel = psort.fetch_elements(vel, order, comm=comm)
+    mass = psort.fetch_elements(mass, order, comm=comm)
+    groupnr_bound = psort.fetch_elements(groupnr_bound, order, comm=comm)
+    bound_rank = psort.fetch_elements(bound_rank, order, comm=comm)
+    ptype = psort.fetch_elements(ptype, order, comm=comm)
+    message("Sorted particles by destination")
+    
+    # Count particles to go to each rank
+    nr_per_rank = np.bincount(particle_rank, minlength=comm_size)
+    comm.Allreduce(MPI.IN_PLACE, nr_per_rank)
+    nr_total_particles = comm.allreduce(nr_parts)
+    assert np.sum(nr_per_rank) == nr_total_particles
+    message("Counted particles per rank")
+
+    # Repartition particles: should leave all on the same rank as their subhalo
+    particle_rank = psort.repartition(particle_rank, ndesired=nr_per_rank, comm=comm)
+    pos = psort.repartition(pos, ndesired=nr_per_rank, comm=comm)
+    vel = psort.repartition(vel, ndesired=nr_per_rank, comm=comm)
+    mass = psort.repartition(mass, ndesired=nr_per_rank, comm=comm)
+    groupnr_bound = psort.repartition(groupnr_bound, ndesired=nr_per_rank, comm=comm)
+    bound_rank = psort.repartition(bound_rank, ndesired=nr_per_rank, comm=comm)
+    ptype = psort.repartition(ptype, ndesired=nr_per_rank, comm=comm)
+    assert np.all(particle_rank==comm_rank)
+    del particle_rank
+    
+    # Now need to locally sort particles by group membership and then bound rank
+    sort_key_t = np.dtype([("groupnr_bound", groupnr_bound.dtype),
+                           ("bound_rank", bound_rank.dtype)])
+    sort_key = np.ndarray(len(ptype), dtype=sort_key_t)
+    sort_key["groupnr_bound"] = groupnr_bound
+    sort_key["bound_rank"] = bound_rank
+    order = np.argsort(sort_key)
+    pos = pos[order,:]
+    vel = vel[order,:]
+    mass = mass[order]
+    groupnr_bound = groupnr_bound[order]
+    bound_rank = bound_rank[order]
+    ptype = ptype[order]
+    message("Locally sorted particles")
+
+    # Then, for each local subhalo find the corresponding range of particles
+    first_particle_in_this_sub = np.searchsorted(groupnr_bound, subhalo_groupnr, side="left")
+    first_particle_in_next_sub = np.searchsorted(groupnr_bound, subhalo_groupnr, side="right")
+    nr_particles_in_sub = first_particle_in_next_sub - first_particle_in_this_sub
+    message("Identified range of particles in each subhalo")
+
+    # Sanity check: the number of particles found should equal the total
+    # number of tracer type particles in the subhalo. Compute expected number
+    # of tracers in each local subhalo.
+    subhalo_nr_tracers = np.zeros_like(subhalos["Nbound"])
+    if "NboundType" in subhalos.dtype.fields:
+        # Hydro run, so sum tracer types only
+        for tt in tracer_types:
+            subhalo_nr_tracers += subhalos["NboundType"][:,tt]
+    else:
+        # DMO run, so assume all particles are tracers because we don't have NboundType
+        subhalo_nr_tracers = subhalos["Nbound"]
+    assert np.all(subhalo_nr_tracers == nr_particles_in_sub)
+    message("Found expected number of tracer particles in each subhalo")
+
+    # Check that we identified particles in halos correctly
+    for i in range(len(subhalos)):
+        i1 = first_particle_in_this_sub[i]
+        i2 = first_particle_in_next_sub[i]
+        assert np.all(groupnr_bound[i1:i2] == subhalo_groupnr[i])
+    message("Subhalo bound particles have expected groupnr_bound")
+    
+    # Add units to particle arrays from the snapshot
+    #pos = pos * unyt.Unit("snap_length", registry=reg)
+    #vel = vel * unyt.Unit("snap_length/snap_time", registry=reg)
+    #mass = mass * unyt.Unit("snap_mass", registry=reg)
+
+    # Allocate output arrays
+    core_mean_pos = np.zeros((len(subhalos),3), dtype=float)
+    core_sigma_r  = np.zeros(len(subhalos), dtype=float)
+    core_mean_vel = np.zeros((len(subhalos),3), dtype=float)
+    core_sigma_v  = np.zeros(len(subhalos), dtype=float)
+    
+    # Loop over all local subhalos
+    for i in range(len(subhalos)):
+        i1 = first_particle_in_this_sub[i]
+        i2 = min(first_particle_in_next_sub[i], i1+nr_tracers)
+        if i2 > i1:
+            # Find particles in this subhalo
+            sub_part_pos  = pos[i1:i2,:].astype(float)
+            sub_part_vel  = vel[i1:i2,:].astype(float)
+            sub_part_mass = mass[i1:i2].astype(float)
+            # Pick a reference point for this subhalo
+            ref_pos = sub_part_pos[0,:]
+            # Wrap particles to periodic copy closest to the reference point
+            offset = (0.5*boxsize) - ref_pos # offset to place ref_pos at box centre
+            sub_part_pos = ((sub_part_pos + offset) % boxsize) - offset
+            # Get total mass
+            mtot = np.sum(sub_part_mass, dtype=float)
+            # Compute mass weighted mean position
+            dx = sub_part_pos #- ref_pos
+            sum_m_dx = np.sum(sub_part_mass[:,None]*dx, axis=0, dtype=float)
+            pos_mean = sum_m_dx / mtot #+ ref_pos
+            # Compute dispersion in position
+            sum_m_dx2 = np.sum(sub_part_mass[:,None]*dx**2, axis=0, dtype=float)
+            pos_disp = sum_m_dx2 / mtot
+            pos_disp -= pos_mean**2
+            # Compute mass weighted mean velocity
+            sum_m_dv = np.sum(sub_part_mass[:,None]*sub_part_vel, axis=0, dtype=float)
+            vel_mean = sum_m_dv / mtot
+            # Compute dispersion in velocity
+            sum_m_dv2 = np.sum(sub_part_mass[:,None]*sub_part_vel**2, axis=0, dtype=float)
+            vel_disp = sum_m_dv2 / mtot
+            vel_disp -= vel_mean**2
+            # Wrap position back into the box
+            pos_mean = pos_mean % boxsize
+            # Store results
+            core_mean_pos[i,:] = pos_mean
+            core_sigma_r[i] = np.sqrt(np.sum(pos_disp))
+            core_mean_vel[i,:] = vel_mean
+            core_sigma_v[i] = np.sqrt(np.sum(vel_disp))
+
+    message("Computed positions and dispersions")
+            
+    # Put output into input order
+    order = psort.parallel_sort(subhalo_groupnr, return_index=True, comm=comm)
+    core_mean_pos = psort.fetch_elements(core_mean_pos, order, comm=comm)
+    core_sigma_r  = psort.fetch_elements(core_sigma_r, order, comm=comm)    
+    core_mean_vel = psort.fetch_elements(core_mean_vel, order, comm=comm)
+    core_sigma_v  = psort.fetch_elements(core_sigma_v, order, comm=comm)
+    nbound        = psort.fetch_elements(subhalos["Nbound"], order, comm=comm)
+    trackid       = psort.fetch_elements(subhalos["TrackId"], order, comm=comm)
+    parent_trackid = psort.fetch_elements(subhalos["NestedParentTrackId"], order, comm=comm)
+    
+    message("Sorted results")
+            
+    # Write out the results
+    filename = f"{output_dir}/merging_info_{snap_nr:03d}.hdf5"
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    with h5py.File(filename, "w", driver="mpio", comm=comm) as f:
+        f["BoxSize"] = boxsize
+        phdf5.collective_write(f, "CoreComovingPosition", core_mean_pos, comm)
+        phdf5.collective_write(f, "CoreComovingSigmaR",   core_sigma_r, comm)
+        phdf5.collective_write(f, "CorePhysicalVelocity", core_mean_vel, comm)
+        phdf5.collective_write(f, "CorePhysicalSigmaV",   core_sigma_v, comm)
+        phdf5.collective_write(f, "Nbound",               nbound, comm)
+        phdf5.collective_write(f, "TrackId",              trackid, comm)
+        phdf5.collective_write(f, "NestedParentTrackId",  parent_trackid, comm)
+
+    comm.barrier()
+    message("Done")
+
+    
+if __name__ == "__main__":
+
+    from virgo.mpi.util import MPIArgumentParser
+
+    parser = MPIArgumentParser(comm, description='Compute HBTplus merging criteria.')
+    parser.add_argument('snapshot_format', help='Format string for snapshot filenames (using {snap_nr}, {file_nr})')
+    parser.add_argument('membership_format', help='Format string for halo membership filenames (using {snap_nr}, {file_nr})')
+    parser.add_argument('hbt_basedir', help='Location of the HBTplus output')
+    parser.add_argument('output_dir', help='Where to write the output')
+    parser.add_argument('snap_nr', type=int, help='Snapshot number to do')
+    args = parser.parse_args()
+
+    compute_merging_condition(**vars(args))
+    

--- a/testing/subhalo_mergers/plot_failed_mergers.py
+++ b/testing/subhalo_mergers/plot_failed_mergers.py
@@ -1,0 +1,87 @@
+#!/bin/env python
+
+import matplotlib
+matplotlib.use('Agg')
+
+import sys
+
+import numpy as np
+import h5py
+import matplotlib.pyplot as plt
+
+snap_nr=int(sys.argv[1])
+branch=sys.argv[2]
+
+filename = f"/cosma8/data/dp004/jch/failed_mergers/COLIBRE/L0050N0376/Thermal_non_equilibrium/{branch}/failed_mergers/failed_mergers_{snap_nr:03d}.hdf5"
+with h5py.File(filename, "r") as f:
+    fm = f["failed_merger"][...]
+    fm_idx = f["failed_merger_idx"][...]
+    r_sep = f["r_sep"][...]
+    v_sep = f["v_sep"][...]
+    r_sep_parent = f["r_sep_parent"][...]
+    v_sep_parent = f["v_sep_parent"][...]
+
+# Also read TrackId etc
+merger_file = filename.replace("/failed_mergers_", "/merging_info_")
+with h5py.File(merger_file, "r") as f:
+    trackid = f["TrackId"][...]
+    nbound = f["Nbound"][...]
+
+#
+# Plot things which should have merged but didn't
+#
+plt.figure(figsize=(8,10))
+plt.subplot(2,1,1)
+plt.plot(r_sep[fm==1], v_sep[fm==1], "r.", label="Not linked by HBT")
+plt.plot(r_sep[fm==2], v_sep[fm==2], "g.", label="Linked by HBT")
+plt.xscale("log")
+plt.xlabel("Normalised position offset")
+plt.yscale("log")
+plt.ylabel("Normalised velocity offset")
+plt.legend(loc="upper right")
+
+# Plot line r_sep + v_sep = 2
+r_points = np.logspace(-2.0, 1.0, 100)
+v_points = 2 - r_points
+plt.plot(r_points, v_points, "k:")
+
+plt.xlim(0.01, 100.0)
+plt.ylim(0.01, 100.0)
+plt.title("Subhalos which should have merged but didn't")
+
+# Identify subhalos which should have been merged which
+# were linked by HBT
+weird_halo = (r_sep+v_sep < 2.0) & (fm==2)
+i1 = np.arange(len(fm), dtype=int)[weird_halo]
+i2 = fm_idx[weird_halo]
+for i, j in zip(i1, i2):
+    print(i, j, "TrackId = ", trackid[i], trackid[j], "Nbounds = ", nbound[i], nbound[j])
+
+#
+# Plot each subhalo's phase space distance to parent
+#
+plt.subplot(2,1,2)
+
+have_parent = (r_sep_parent >= 0)
+
+plt.plot(r_sep_parent[have_parent], v_sep_parent[have_parent], "k,", rasterized=True)
+plt.xscale("log")
+plt.xlabel("Normalised position offset")
+plt.yscale("log")
+plt.ylabel("Normalised velocity offset")
+
+# Plot line r_sep + v_sep = 2
+r_points = np.logspace(-2.0, 1.0, 100)
+v_points = 2 - r_points
+plt.plot(r_points, v_points, "k:")
+
+plt.xlim(0.01, 100.0)
+plt.ylim(0.01, 100.0)
+plt.title("Phase space distance to parent for all subhalos")
+
+plt.tight_layout()
+plt.savefig(f"./plots/failed_mergers_{branch}_{snap_nr:03d}.png")
+
+#plt.show()
+
+


### PR DESCRIPTION
HBT-HERONS outputs can contain instances where two subhalos are completely overlapping in phase space but which are not merged by HBT because it isn't aware that one is a subhalo of the other. This can happen because there is a genuine physical merger between subhalos, or it can be an artifact of having insufficient time resolution.

Here I've added some scripts in testing/subhalo_mergers which recompute the merging criterion from HBT output and identify instances of subhalos which should have been merged but have not.

I've also added a function to HBT which tries to identify if a subhalo should be reclassified as a sub-subhalo of another subhalo. This is done as follows:

In each FoF group we iterate over subhalos in descending order of mass. For each subhalo A we check if there is a less massive subhalo B which has its centre somewhere within the spatial extent of subhalo A but which is not already nested within A. If so, we might want to set the subhalo B to be nested within A. In order to make sure we don't prevent any mergers which might have happened without this change, we only make the change if the new parent subhalo of B is nested somewhere inside the original parent of B (which is likely to be the main halo in most cases).

Currently I'm doing this check after the unbinding and merging step because the halos are fully defined at that point. But it might be better to do it before unbinding so that the change takes effect a snapshot earlier. I'm also defining the spatial extent of the subhalo as twice the half mass radius from the previous snapshot because the new half mass radius has not yet been computed.

I'm not yet modifying the nesting hierarchy. The code just assigns a NewParentTrackId property to each subhalo which identifies if a subhalo satisfies the condition to be reassigned.