### PR TITLE
Set SnapshotIndexOfLastIsolation

### DIFF
--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -44,7 +44,8 @@ public:
   int Depth;   // depth of the subhalo: central=0, sub=1, sub-sub=2, ...
   float LastMaxMass;
   int SnapshotIndexOfLastMaxMass; // the snapshot when it has the maximum subhalo mass, only considering past snapshots.
-  int SnapshotIndexOfLastIsolation; // the last snapshot when it was a central, only considering past snapshots. -1 if the subhalo has always been a central
+  int SnapshotIndexOfLastIsolation; // the last snapshot when it was a central, only considering past snapshots. -1 if
+                                    // the subhalo has always been a central
 
   int SnapshotIndexOfBirth; // when the subhalo first becomes resolved
   int SnapshotIndexOfDeath; // when the subhalo first becomes un-resolved; only set if

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -44,7 +44,7 @@ public:
   int Depth;   // depth of the subhalo: central=0, sub=1, sub-sub=2, ...
   float LastMaxMass;
   int SnapshotIndexOfLastMaxMass; // the snapshot when it has the maximum subhalo mass, only considering past snapshots.
-  int SnapshotIndexOfLastIsolation; // the last snapshot when it was a central, only considering past snapshots.
+  int SnapshotIndexOfLastIsolation; // the last snapshot when it was a central, only considering past snapshots. -1 if the subhalo has always been a central
 
   int SnapshotIndexOfBirth; // when the subhalo first becomes resolved
   int SnapshotIndexOfDeath; // when the subhalo first becomes un-resolved; only set if

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -15,7 +15,13 @@ void Subhalo_t::UpdateTrack(const Snapshot_t &epoch)
     return;
 
   if (0 == Rank)
-    SnapshotIndexOfLastIsolation = epoch.GetSnapshotIndex();
+  {
+    if (SnapshotIndexOfLastIsolation != SpecialConst::NullSnapshotId)
+    {
+      // Subhalo has been a satellite at some point in the past
+      SnapshotIndexOfLastIsolation = epoch.GetSnapshotIndex();
+    }
+  }
   if (Mbound >= LastMaxMass)
   {
     SnapshotIndexOfLastMaxMass = epoch.GetSnapshotIndex();
@@ -927,6 +933,11 @@ void SubhaloSnapshot_t::SetNestedParentIds()
     for (auto &nested_trackid : subhalo.NestedSubhalos)
     {
       HBTInt child_index = TrackHash.GetIndex(nested_trackid);
+      if (Subhalos[child_index].SnapshotIndexOfLastIsolation == SpecialConst::NullSnapshotId)
+      {
+        // Subhalo had been a central up to this snapshot
+        Subhalos[child_index].SnapshotIndexOfLastIsolation = GetSnapshotIndex() - 1;
+      }
       Subhalos[child_index].NestedParentTrackId = subhalo.TrackId;
     }
   }


### PR DESCRIPTION
It would be useful to have an easy way to identify which subhalos have always been centrals (e.g. for analysis of splashback objects). This PR slightly changes the meaning of `SnapshotIndexOfLastIsolation`, in that it now will be -1 for objects that have never been a satellite. This is actually in line with the current documentation on the website.

Some users might be using the value of `SnapshotIndexOfLastIsolation` to determine if an object is central, but there's other ways to do that easily.