### PR TITLE
Make the merging criterion symmetric

### DIFF
--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -17,7 +17,18 @@ float Subhalo_t::PhaseSpaceDistance(const Subhalo_t &ReferenceSubhalo)
 {
   float position_offset = PeriodicDistance(ReferenceSubhalo.CoreComovingPosition, CoreComovingPosition);
   float velocity_offset = Distance(ReferenceSubhalo.CorePhysicalVelocity, CorePhysicalVelocity);
-  return position_offset / ReferenceSubhalo.CoreComovingSigmaR + velocity_offset / ReferenceSubhalo.CorePhysicalSigmaV;
+  float distance = position_offset / ReferenceSubhalo.CoreComovingSigmaR + velocity_offset / ReferenceSubhalo.CorePhysicalSigmaV;
+
+  // Force the merging criterion to be symmetric where possible. I.e. if A
+  // merges with B then B merges with A too. Here we compute the distance
+  // if we reverse this subhalo and the reference subhalo and use the
+  // smaller value to decide if we have a merger. Orphans don't have a
+  // dispersion so can't be handled this way.
+  if(Nbound > 1) {
+    float reverse_distance = position_offset / CoreComovingSigmaR + velocity_offset / CorePhysicalSigmaV;
+    distance = std::min(distance, reverse_distance);
+  }
+  return distance;
 }
 
 /* Check if the current subhalo satisfies merger criterion with a reference one. */

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -19,11 +19,10 @@ float Subhalo_t::PhaseSpaceDistance(const Subhalo_t &ReferenceSubhalo)
   float velocity_offset = Distance(ReferenceSubhalo.CorePhysicalVelocity, CorePhysicalVelocity);
   float distance = position_offset / ReferenceSubhalo.CoreComovingSigmaR + velocity_offset / ReferenceSubhalo.CorePhysicalSigmaV;
 
-  // Force the merging criterion to be symmetric where possible. I.e. if A
-  // merges with B then B merges with A too. Here we compute the distance
-  // if we reverse this subhalo and the reference subhalo and use the
-  // smaller value to decide if we have a merger. Orphans don't have a
-  // dispersion so can't be handled this way.
+  // Force the merging criterion to be symmetric where possible. Here we
+  // compute the distance if we reverse this subhalo and the reference subhalo
+  // and use the smaller value to decide if we have a merger. Orphans don't
+  // have a dispersion so can't be handled this way.
   if(Nbound > 1) {
     float reverse_distance = position_offset / CoreComovingSigmaR + velocity_offset / CorePhysicalSigmaV;
     distance = std::min(distance, reverse_distance);


### PR DESCRIPTION
To check for mergers HBT computes the separation between a host and satellite subhalo in position and velocity space and normalizes by the dispersion of the 10 most bound tracer particles of the host. This PR makes it repeat the calculation using the dispersion of the satellite's tracer particles and it uses the smaller of the two values to decide if the subhalos merge.