### PR TITLE
Output potential energy

### DIFF
--- a/examples/configs/Example.conf
+++ b/examples/configs/Example.conf
@@ -65,6 +65,10 @@ SaveBoundParticleProperties 0
 # bound to a subhalo.
 SaveBoundParticleBindingEnergies 0
 
+# If the potential energies of particles should be saved alongside the subhalo
+# catalogues. This is only provided for particles that are bound to a subhalo.
+SaveBoundParticlePotentialEnergies 0
+
 [==================================== UNITS ===================================]
 
 # What units should be used. They should always be provided, either through

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -54,6 +54,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(SnapshotIdUnsigned);
   TrySetPar(SaveBoundParticleProperties);
   TrySetPar(SaveBoundParticleBindingEnergies);
+  TrySetPar(SaveBoundParticlePotentialEnergies);
   TrySetPar(MergeTrappedSubhalos);
   TrySetPar(MajorProgenitorMassRatio);
   TrySetPar(BoundMassPrecision);
@@ -292,6 +293,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncBool(SnapshotIdUnsigned);
   _SyncBool(SaveBoundParticleProperties);
   _SyncBool(SaveBoundParticleBindingEnergies);
+  _SyncBool(SaveBoundParticlePotentialEnergies);
   _SyncBool(MergeTrappedSubhalos);
   _SyncVec(SnapshotIdList, MPI_INT);
   world.SyncVectorString(SnapshotNameList, root);
@@ -398,6 +400,7 @@ void Parameter_t::DumpParameters()
   DumpPar(SnapshotIdUnsigned);
   DumpPar(SaveBoundParticleProperties);
   DumpPar(SaveBoundParticleBindingEnergies);
+  DumpPar(SaveBoundParticlePotentialEnergies);
 #ifndef DM_ONLY
   DumpPar(ParticlesSplit);
 #endif

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -55,6 +55,7 @@ public:
   bool SnapshotIdUnsigned;
   bool SaveBoundParticleProperties;
   bool SaveBoundParticleBindingEnergies;
+  bool SaveBoundParticlePotentialEnergies;
   bool MergeTrappedSubhalos; // whether to MergeTrappedSubhalos, see code paper for more info.
   vector<int> SnapshotIdList;
   vector<int> TracerParticleTypes;
@@ -109,6 +110,7 @@ public:
     SnapshotIdUnsigned = false;
     SaveBoundParticleProperties = false;
     SaveBoundParticleBindingEnergies = false;
+    SaveBoundParticlePotentialEnergies = false;
 #ifdef NO_STRIPPING
     MergeTrappedSubhalos = false;
 #else

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -439,6 +439,21 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
     H5Tclose(H5T_FloatArr);
   }
 
+  if (HBTConfig.SaveBoundParticlePotentialEnergies)
+  {
+    hid_t H5T_FloatArr = H5Tvlen_create(H5T_NATIVE_FLOAT);
+    for (HBTInt i = 0; i < vl.size(); i++)
+    {
+      vl[i].len = Subhalos[i].Nbound;
+      vl[i].p = Subhalos[i].ParticlePotentialEnergies.data();
+
+      /* Clear the vector to reduce memory footprint and because it will be overwritten anyway. */
+      Subhalos[i].ParticlePotentialEnergies.clear();
+    }
+    writeHDFmatrix(file, vl.data(), "PotentialEnergies", ndim, dim_sub, H5T_FloatArr);
+    H5Tclose(H5T_FloatArr);
+  }
+
   vector<HBTInt> IdBuffer;
   {
     HBTInt NumberOfParticles = 0;

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -45,6 +45,7 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   InsertMember(SnapshotIndexOfDeath, H5T_NATIVE_INT);
   InsertMember(SnapshotIndexOfSink, H5T_NATIVE_INT);
   InsertMember(RmaxComoving, H5T_NATIVE_FLOAT);
+  InsertMember(RmaxComovingOfLastMaxVmax, H5T_NATIVE_FLOAT);
   InsertMember(VmaxPhysical, H5T_NATIVE_FLOAT);
   InsertMember(LastMaxVmaxPhysical, H5T_NATIVE_FLOAT);
   InsertMember(SnapshotIndexOfLastMaxVmax, H5T_NATIVE_INT);

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -161,6 +161,7 @@ void SubhaloSnapshot_t::BuildMPIDataType()
   RegisterAttr(SnapshotIndexOfDeath, MPI_INT, 1);
   RegisterAttr(SnapshotIndexOfSink, MPI_INT, 1);
   RegisterAttr(RmaxComoving, MPI_FLOAT, 1);
+  RegisterAttr(RmaxComovingOfLastMaxVmax, MPI_FLOAT, 1);
   RegisterAttr(VmaxPhysical, MPI_FLOAT, 1);
   RegisterAttr(LastMaxVmaxPhysical, MPI_FLOAT, 1);
   RegisterAttr(SnapshotIndexOfLastMaxVmax, MPI_INT, 1);
@@ -271,8 +272,9 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   /* to calculate the following density-profile related properties
    *
   HBTReal RmaxComoving;
+  HBTReal RmaxComovingOfLastMaxVmax;
   HBTReal VmaxPhysical;
-  HBTReal LastMaxVmax;
+  HBTReal LastMaxVmaxPhysical;
   HBTInt SnapshotIndexOfLastMaxVmax; //the snapshot when it has the maximum Vmax, only considering past snapshots.
 
   HBTReal REncloseComoving;
@@ -343,6 +345,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   {
     SnapshotIndexOfLastMaxVmax = epoch.GetSnapshotIndex();
     LastMaxVmaxPhysical = VmaxPhysical;
+    RmaxComovingOfLastMaxVmax = RmaxComoving;
   }
 }
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -98,9 +98,10 @@ public:
 
   ParticleList_t Particles;
 
-  /* Binding energies of the particles bound to the subhalo. It is a separate instance from ParticleList_t
-   * because it does not need communicating before unbinding. */
+  /* Binding/potential energies of the particles bound to the subhalo. They are a separate instance from ParticleList_t
+   * because they do not need communicating before unbinding. */
   vector<float> ParticleBindingEnergies;
+  vector<float> ParticlePotentialEnergies;
 
   SubIdList_t NestedSubhalos; // list of sub-in-subs.
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -54,6 +54,7 @@ public:
 
   // profile properties
   float RmaxComoving;
+  float RmaxComovingOfLastMaxVmax;
   float VmaxPhysical;
   float LastMaxVmaxPhysical;
   int SnapshotIndexOfLastMaxVmax; // the snapshot when it has the maximum Vmax, only considering past snapshots.
@@ -129,6 +130,7 @@ public:
     SnapshotIndexOfLastIsolation = SpecialConst::NullSnapshotId;
     SnapshotIndexOfLastMaxMass = SpecialConst::NullSnapshotId;
     LastMaxMass = 0.;
+    RmaxComovingOfLastMaxVmax = 0.;
     LastMaxVmaxPhysical = 0.;
     SnapshotIndexOfLastMaxVmax = SpecialConst::NullSnapshotId;
     SnapshotIndexOfBirth = SpecialConst::NullSnapshotId;

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -117,6 +117,8 @@ public:
   }
   HBTReal GetPotentialEnergy(HBTInt i, const HBTxyz &refPos, const HBTxyz &refVel) const
   {
+    // Load the total binding energy of the particle, then remove the thermal
+    // and kinetic terms so we can return the potential energy
     HBTReal E = Elist[i].E;
 #ifdef UNBIND_WITH_THERMAL_ENERGY
     E -= GetInternalEnergy(i);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -109,8 +109,8 @@ public:
   }
   HBTReal GetInternalEnergy(HBTInt i) const
   {
-#if !defined(DM_ONLY) && defined(UNBIND_WITH_THERMAL_ENERGY)
-    return Particles[index].InternalEnergy;
+#if !defined(DM_ONLY) && defined(HAS_THERMAL_ENERGY)
+    return Particles[GetParticle(i)].InternalEnergy;
 #else
     return 0.;
 #endif

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -109,7 +109,7 @@ public:
   }
   HBTReal GetInternalEnergy(HBTInt i) const
   {
-#if !defined(DM_ONLY) && defined(HAS_THERMAL_ENERGY)
+#ifdef HAS_THERMAL_ENERGY
     return Particles[GetParticle(i)].InternalEnergy;
 #else
     return 0.;
@@ -131,7 +131,7 @@ public:
         dx[j] = NEAREST(dx[j]);
       dx[j] *= Cosmology.ScaleFactor; // physical
       dv[j] = v[j] - refVel[j] + Cosmology.Hz * dx[j];
-      E -= dv[j] * dv[j];
+      E -= 0.5 * dv[j] * dv[j];
     }
     return E;
   }

--- a/testing/config_test.txt
+++ b/testing/config_test.txt
@@ -35,10 +35,11 @@ MaxSampleSizeOfPotentialEstimate 0
 
 # Test simulation does not provide splitting information
 ParticlesSplit 0
-SaveBoundParticleBindingEnergies 1
+SaveBoundParticlePotentialEnergies 1
 
 # Optional parameters; default values are shown here
 #MinNumPartOfSub 20
 #PeriodicBoundaryOn 1
 #SaveBoundParticleProperties 0
+#SaveBoundParticleBindingEnergies 0
 #TracerParticleTypes 1 4 

--- a/testing/config_test.txt
+++ b/testing/config_test.txt
@@ -35,11 +35,12 @@ MaxSampleSizeOfPotentialEstimate 0
 
 # Test simulation does not provide splitting information
 ParticlesSplit 0
+
 SaveBoundParticlePotentialEnergies 1
+SaveBoundParticleBindingEnergies 1
 
 # Optional parameters; default values are shown here
 #MinNumPartOfSub 20
 #PeriodicBoundaryOn 1
 #SaveBoundParticleProperties 0
-#SaveBoundParticleBindingEnergies 0
 #TracerParticleTypes 1 4 

--- a/toolbox/swiftsim/pipeline/templates/template_config.txt
+++ b/toolbox/swiftsim/pipeline/templates/template_config.txt
@@ -26,4 +26,4 @@ TracerParticleTypes 1 4
 MinNumTracerPartOfSub 10
 
 [Additional information]
-SaveBoundParticleBindingEnergies 1
+SaveBoundParticlePotentialEnergies 1


### PR DESCRIPTION
Similar to https://github.com/SWIFTSIM/HBT-HERONS/pull/63, but now outputting potential energy.

Also has a minor fix to the `SpecificPotentialEnergy` HBT outputs, which was not accounting for thermal energy.

I have used this branch to run the cosma7 test. Also see https://github.com/SWIFTSIM/SOAP/pull/132