### PR TITLE
Squash bug in git hash

### DIFF
--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -367,8 +367,8 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
 
   /* Version information */
   hid_t header = H5Gcreate2(file, "/Header", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-  writeStringAttribute(header, "Git_branch", branch_name);
-  writeStringAttribute(header, "Git_commit", commit_hash);
+  writeStringAttribute(header, branch_name, "Git_branch");
+  writeStringAttribute(header, commit_hash, "Git_commit");
   H5Gclose(header);
 
   vector<hvl_t> vl(Subhalos.size());


### PR DESCRIPTION
We've been storing the hash as the key, not the value.  See https://github.com/SWIFTSIM/HBT-HERONS/blob/31abb6cff47b6e376fe7105439f1f641c9123247/src/hdf_wrapper.cpp#L29

I've run the test with this to confirm it works.
