### PR TITLE
Store particle with minimum potential

### DIFF
--- a/src/gravity_tree.cpp
+++ b/src/gravity_tree.cpp
@@ -165,6 +165,14 @@ double GravityTree_t::EvaluatePotential(const HBTxyz &targetPos, const HBTReal t
   return pot * PhysicalConst::G / Snapshot->Cosmology.ScaleFactor;
 }
 
+double GravityTree_t::KineticEnergy(const HBTxyz &targetPos, const HBTxyz &targetVel, const HBTxyz &refPos,
+                                    const HBTxyz &refVel)
+{
+  HBTxyz dv;
+  Snapshot->RelativeVelocity(targetPos, targetVel, refPos, refVel, dv);
+  return VecNorm(dv) * 0.5;
+}
+
 double GravityTree_t::BindingEnergy(const HBTxyz &targetPos, const HBTxyz &targetVel, const HBTxyz &refPos,
                                     const HBTxyz &refVel, const HBTReal targetMass)
 /* return specific binding energy

--- a/src/gravity_tree.h
+++ b/src/gravity_tree.h
@@ -15,6 +15,7 @@ private:
 
 public:
   double EvaluatePotential(const HBTxyz &targetPos, const HBTReal targetMass = 0.);
+  double KineticEnergy(const HBTxyz &targetPos, const HBTxyz &targetVel, const HBTxyz &refPos, const HBTxyz &refVel);
   double BindingEnergy(const HBTxyz &targetPos, const HBTxyz &targetVel, const HBTxyz &refPos, const HBTxyz &refVel,
                        const HBTReal targetMass = 0.);
 };

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -77,6 +77,7 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   InsertMember(ComovingAveragePosition, H5T_HBTxyz);
   InsertMember(PhysicalAverageVelocity, H5T_HBTxyz);
   InsertMember(ComovingMostBoundPosition, H5T_HBTxyz);
+  InsertMember(ComovingMinPotentialPosition, H5T_HBTxyz);
   InsertMember(PhysicalMostBoundVelocity, H5T_HBTxyz);
   InsertMember(MostBoundParticleId, H5T_HBTInt);
 

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -185,6 +185,7 @@ void SubhaloSnapshot_t::BuildMPIDataType()
   RegisterAttr(ComovingAveragePosition[0], MPI_HBT_REAL, 3);
   RegisterAttr(PhysicalAverageVelocity[0], MPI_HBT_REAL, 3);
   RegisterAttr(ComovingMostBoundPosition[0], MPI_HBT_REAL, 3);
+  RegisterAttr(ComovingMinPotentialPosition[0], MPI_HBT_REAL, 3);
   RegisterAttr(PhysicalMostBoundVelocity[0], MPI_HBT_REAL, 3);
 
   assert(offsets[NumAttr - 1] - offsets[NumAttr - 2] == sizeof(HBTReal) * 3); // to make sure HBTxyz is stored locally.

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -88,6 +88,7 @@ public:
   HBTxyz ComovingAveragePosition;
   HBTxyz PhysicalAverageVelocity;   // default vel of sub
   HBTxyz ComovingMostBoundPosition; // default pos of sub
+  HBTxyz ComovingMinPotentialPosition; // position of bound particle with minimum potential
   HBTxyz PhysicalMostBoundVelocity;
   HBTInt MostBoundParticleId; // a shortcut to the first particle in Particles, for easier IO in GALFORM
 

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -95,6 +95,7 @@ void Subhalo_t::GetCorePhaseSpaceProperties()
    * associated to them explicitly*/
   if (Nbound == 0)
   {
+    // What to do with minimum potential
     copyHBTxyz(CoreComovingPosition, ComovingMostBoundPosition);
     copyHBTxyz(CorePhysicalVelocity, PhysicalMostBoundVelocity);
     CoreComovingSigmaR = 0.;
@@ -217,6 +218,7 @@ void Subhalo_t::MergeTo(Subhalo_t &host)
    * are based on the ACTUAL MOST BOUND PARTICLE. Orphans are based on the
    * MOST BOUND TRACER PARTICLE. */
   MostBoundParticleId = Particles[GetTracerIndex()].Id;
+    // What to do with minimum potential
   copyHBTxyz(ComovingMostBoundPosition, Particles[GetTracerIndex()].ComovingPosition);
   copyHBTxyz(PhysicalMostBoundVelocity, Particles[GetTracerIndex()].GetPhysicalVelocity());
   copyHBTxyz(ComovingAveragePosition, ComovingMostBoundPosition);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -303,7 +303,7 @@ inline HBTxyz RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gra
                                        RefVel);
       if (pot < min_pot) {
         min_pot = pot;
-        copyHBTxyz(ComovingMinPotentialPosition, Particles[i].ComovingPosition);
+        copyHBTxyz(ComovingMinPotentialPosition, Particles[pid].ComovingPosition);
       }
     }
 #pragma omp single
@@ -567,7 +567,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
       pot = ESnap.GetPotentialEnergy(i, RefPos, RefVel);
       if (pot < min_pot) {
         min_pot = pot;
-        copyHBTxyz(ComovingMinPotentialPosition, Particles[i].ComovingPosition);
+        copyHBTxyz(ComovingMinPotentialPosition, ESnap.GetComovingPosition(i));
       }
     }
   }


### PR DESCRIPTION
Some people are asking for the minimum potential to use as a halo centre rather than the most bound particle. This PR stores the position of the particle with the minimum potential energy.

At this point this is just to see the level of difference. This would need cleaned up if we wanted to merge these changes.  