### PR TITLE
Read in H(z) value

### DIFF
--- a/src/io/swiftsim_io.h
+++ b/src/io/swiftsim_io.h
@@ -23,6 +23,7 @@ struct SwiftSimHeader_t
   double ScaleFactor;
   double OmegaM0;
   double OmegaLambda0;
+  double Hz;
   double h;
   double mass[TypeMax];
   int npart[TypeMax];

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -352,16 +352,6 @@ void Snapshot_t::SphericalOverdensitySize2(float &Mvir, float &Rvir, HBTReal Vir
   Mvir = ndiv * ParticleMass;
 }
 
-void Snapshot_t::HaloVirialFactors(HBTReal &virialF_tophat, HBTReal &virialF_b200, HBTReal &virialF_c200) const
-{
-  HBTReal Hratio, x;
-  Hratio = Cosmology.Hz / PhysicalConst::H0;
-  x = Cosmology.OmegaZ - 1;
-  virialF_tophat = 18.0 * 3.1416 * 3.1416 + 82.0 * x - 39.0 * x * x; //<Rho_vir>/Rho_cri
-  virialF_c200 = 200.;
-  virialF_b200 = 200. * Cosmology.OmegaZ; // virialF w.r.t contemporary critical density
-}
-
 void ParticleSnapshot_t::ClearParticles()
 /*this allows us to clear the particle data when it's no longer needed*/
 {

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -21,21 +21,34 @@ struct Cosmology_t
   HBTReal OmegaLambda0;
   HBTReal ScaleFactor;
 
-  // derived parameters:
-  HBTReal Hz; // current Hubble param in internal units
-  HBTReal OmegaZ;
+  // current Hubble param in internal units
+  // we try to read this in if possible, otherwise derive it
+  HBTReal Hz = -1.0;
+
+  void Set_Hz(double hz)
+  {
+    Hz = hz;
+  }
 
   void Set(double scalefactor, double omega0, double omegaLambda0)
   {
     OmegaM0 = omega0;
     OmegaLambda0 = omegaLambda0;
     ScaleFactor = scalefactor;
-    double Hratio = sqrt(omega0 / (scalefactor * scalefactor * scalefactor) +
+
+    double Hratio;
+    if (Hz == -1.0)
+    {
+      Hratio = sqrt(omega0 / (scalefactor * scalefactor * scalefactor) +
                          (1 - omega0 - omegaLambda0) / (scalefactor * scalefactor) +
-                         omegaLambda0); // Hubble param for the current catalogue;
+                         omegaLambda0);
+      Hz = Hratio * PhysicalConst::H0;
+    } else
+    {
+      Hratio = Hz / PhysicalConst::H0;
+    }
 
     Hz = Hratio * PhysicalConst::H0;
-    OmegaZ = omega0 / (scalefactor * scalefactor * scalefactor) / Hratio / Hratio;
   }
 };
 
@@ -112,7 +125,6 @@ public:
   void SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor, const vector<RadMassVel_t> &prof) const;
   void SphericalOverdensitySize2(float &Mvir, float &Rvir, HBTReal VirialFactor, const vector<HBTReal> &RSorted,
                                  HBTReal ParticleMass) const;
-  void HaloVirialFactors(HBTReal &virialF_tophat, HBTReal &virialF_b200, HBTReal &virialF_c200) const;
   void RelativeVelocity(const HBTxyz &targetPos, const HBTxyz &targetVel, const HBTxyz &refPos, const HBTxyz &refVel,
                         HBTxyz &relativeVel) const;
 };

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -335,11 +335,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
   RHalfComoving = prof[Nbound / 2].r;
   REncloseComoving = prof[Nbound - 1].r;
 
-  HBTReal virialF_tophat, virialF_b200, virialF_c200;
-  epoch.HaloVirialFactors(virialF_tophat, virialF_b200, virialF_c200);
-  //   epoch.SphericalOverdensitySize(MVir, RVirComoving, virialF_tophat, prof);
-  epoch.SphericalOverdensitySize(BoundM200Crit, BoundR200CritComoving, virialF_c200, prof);
-  //   epoch.SphericalOverdensitySize(M200Mean, R200MeanComoving, virialF_b200, prof);
+  epoch.SphericalOverdensitySize(BoundM200Crit, BoundR200CritComoving, 200., prof);
 
   if (VmaxPhysical >= LastMaxVmaxPhysical)
   {


### PR DESCRIPTION
For the DESI FLAMINGO run we need to be able to calculate H(z) for cosmologies with `w != -1`. I am just copying the value directly from the swift header rather than trying to calculate it. 

In the course of making this change I noticed a bug, where we calculated H(z) before reading in the unit system from the swift snapshot. See https://leiden-observatory.slack.com/archives/C0697E1L4MA/p1747147814182049 This bug is now fixed.

We are definitely not using the correct omega_M values for any DCDM runs. Thankfully this value is only used for calculating Rvir, so I've just stripped that code out. Handling DCDM is also the reason why I decided to just copy the H(z) value from the snapshots directly.