### PR TITLE
Do not overwrite a True value of ExperiencedMerger

### DIFF
--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -75,7 +75,7 @@ bool Subhalo_t::MergeRecursively(SubhaloList_t &Subhalos, const Snapshot_t &snap
 
       /* Flag if the subhalo was previously resolved, and hence the reference
        * subhalo will accrete particles resulting from the merger. */
-      ExperiencedMerger = Nbound > 1;
+      ExperiencedMerger = ExperiencedMerger ? ExperiencedMerger : Nbound > 1;
 
       /* If enabled, pass the particles to the reference subhalo we merged to. */
       if (HBTConfig.MergeTrappedSubhalos)

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -61,8 +61,9 @@ bool Subhalo_t::MergeRecursively(SubhaloList_t &Subhalos, const Snapshot_t &snap
     auto ChildIndex = NestedSubhalos[i];
     auto &ChildSubhalo = Subhalos[ChildIndex];
 
-    /* Go further down the hierarchy if possible */
-    ExperiencedMerger = ChildSubhalo.MergeRecursively(Subhalos, snap, ReferenceSubhalo);
+    /* Go further down the hierarchy if possible. Comparison is done to not
+     * overwrite true value. */
+    ExperiencedMerger = ChildSubhalo.MergeRecursively(Subhalos, snap, ReferenceSubhalo) | ExperiencedMerger;
   }
 
   /* Only deal with present subhalo if is not already trapped and it is not the
@@ -77,7 +78,7 @@ bool Subhalo_t::MergeRecursively(SubhaloList_t &Subhalos, const Snapshot_t &snap
        * subhalo will accrete particles resulting from the merger. We do not
        * overwrite the value in case we find a merger with an unresolved subhalo
        * after finding a merger with a resolved subhalo.  */
-      ExperiencedMerger = ExperiencedMerger ? ExperiencedMerger : Nbound > 1;
+      ExperiencedMerger = Nbound > 1 | ExperiencedMerger;
 
       /* If enabled, pass the particles to the reference subhalo we merged to. */
       if (HBTConfig.MergeTrappedSubhalos)

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -74,7 +74,9 @@ bool Subhalo_t::MergeRecursively(SubhaloList_t &Subhalos, const Snapshot_t &snap
       SetMergerInformation(ReferenceSubhalo.TrackId, snap.GetSnapshotIndex());
 
       /* Flag if the subhalo was previously resolved, and hence the reference
-       * subhalo will accrete particles resulting from the merger. */
+       * subhalo will accrete particles resulting from the merger. We do not
+       * overwrite the value in case we find a merger with an unresolved subhalo
+       * after finding a merger with a resolved subhalo.  */
       ExperiencedMerger = ExperiencedMerger ? ExperiencedMerger : Nbound > 1;
 
       /* If enabled, pass the particles to the reference subhalo we merged to. */


### PR DESCRIPTION
Whilst investigating major mergers that go wrong, I noticed a line that may introduce a bug.

The code checks whether the subhalo that has merged is resolved, and based on that, whether `ExperiencedMerger` should be `True` or `False`. The value of this flag determines whether the subhalo that has accreted the particles need to undergo another round of unbinding to account for the newly accreted mass. https://github.com/SWIFTSIM/HBT-HERONS/blob/c5e52031ab1c1513c6a36ef41b1a470a6004dfcc/src/subhalo_unbind.cpp#L575

The reason why I think the line would cause a bug is if we have a merger, but we then find subsequently identify an orphan merger. Depending on the order in which each pair of potentially overlapping subhaloes is checked, the newly merged orphan might override the value of the flag, Hence, the particles of a merged resolved subhalo will be left in limbo and not bound to anything.

This fix makes it so that we do not overwrite the value of `ExperiencedMerger` if it is already `True`