### PR TITLE
Make subsampling mass factor be based on particle mass rather than number.

### DIFF
--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -43,7 +43,7 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
           iterbackward++;
         return iterbackward - Elist.begin();
       }
-      if (iterbackward->E < 0)
+      if (iterbackward->Energy < 0)
         break;
     }
     *iterforward = *iterbackward;
@@ -58,7 +58,7 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
           iterbackward++;
         return iterbackward - Elist.begin();
       }
-      if (iterforward->E > 0)
+      if (iterforward->Energy > 0)
         break;
     }
     *iterbackward = *iterforward;

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -11,13 +11,13 @@
 
 struct ParticleEnergy_t
 {
+  float Energy;
   HBTInt ParticleIndex;
-  float E;
 };
 
 inline bool CompareEnergy(const ParticleEnergy_t &a, const ParticleEnergy_t &b)
 {
-  return (a.E < b.E);
+  return (a.Energy < b.Energy);
 };
 
 static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size_t len)
@@ -26,7 +26,7 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
   if (len == 0)
     return 0;
   if (len == 1)
-    return Elist[0].E < 0;
+    return Elist[0].Energy < 0;
 
   ParticleEnergy_t Etmp = Elist[0];
   auto iterforward = Elist.begin(), iterbackward = Elist.begin() + len;
@@ -39,7 +39,7 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
       if (iterbackward == iterforward)
       {
         *iterforward = Etmp;
-        if (Etmp.E < 0)
+        if (Etmp.Energy < 0)
           iterbackward++;
         return iterbackward - Elist.begin();
       }
@@ -54,7 +54,7 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
       if (iterforward == iterbackward)
       {
         *iterbackward = Etmp;
-        if (Etmp.E < 0)
+        if (Etmp.Energy < 0)
           iterbackward++;
         return iterbackward - Elist.begin();
       }
@@ -70,7 +70,7 @@ static void PopMostBoundParticle(ParticleEnergy_t *Edata, const HBTInt Nbound)
   HBTInt imin = 0;
   for (HBTInt i = 1; i < Nbound; i++)
   {
-    if (Edata[i].E < Edata[imin].E)
+    if (Edata[i].Energy < Edata[imin].Energy)
       imin = i;
   }
   if (imin != 0)
@@ -130,7 +130,7 @@ public:
   {
     // Load the total binding energy of the particle, then remove the thermal
     // and kinetic terms so we can return the potential energy
-    HBTReal E = Elist[i].E;
+    HBTReal E = Elist[i].Energy;
 #ifdef UNBIND_WITH_THERMAL_ENERGY
     E -= GetInternalEnergy(i);
 #endif
@@ -267,7 +267,7 @@ public:
     for (HBTInt i = 0; i < NumPart; i++)
     {
       HBTReal m = GetMass(i);
-      E += Elist[i].E * m;
+      E += Elist[i].Energy * m;
 #ifdef UNBIND_WITH_THERMAL_ENERGY
       E -= GetInternalEnergy(i) * m;
 #endif
@@ -312,7 +312,7 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
     {
       HBTInt pid = Elist[i].ParticleIndex;
       Einner[i].ParticleIndex = i;
-      Einner[i].E = tree.BindingEnergy(Particles[pid].ComovingPosition, Particles[pid].GetPhysicalVelocity(), RefPos,
+      Einner[i].Energy = tree.BindingEnergy(Particles[pid].ComovingPosition, Particles[pid].GetPhysicalVelocity(), RefPos,
                                        RefVel, Particles[pid].Mass);
     }
 #pragma omp single
@@ -401,7 +401,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
         auto v = Particles[pid].GetPhysicalVelocity();
         HBTxyz OldVel;
         epoch.RelativeVelocity(x, v, OldRefPos, OldRefVel, OldVel);
-        Elist[i].E += VecDot(OldVel, RefVelDiff) + dK - tree.EvaluatePotential(x, 0);
+        Elist[i].Energy += VecDot(OldVel, RefVelDiff) + dK - tree.EvaluatePotential(x, 0);
       }
       Nlast = Nbound;
     }
@@ -424,10 +424,10 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
           mass = ESnap.GetMass(i); // to correct for self-gravity
         else
           mass = 0.; // not sampled in tree, no self gravity to correct
-        Elist[i].E = tree.BindingEnergy(Particles[pid].ComovingPosition, Particles[pid].GetPhysicalVelocity(), RefPos,
+        Elist[i].Energy = tree.BindingEnergy(Particles[pid].ComovingPosition, Particles[pid].GetPhysicalVelocity(), RefPos,
                                         RefVel, mass);
 #ifdef UNBIND_WITH_THERMAL_ENERGY
-        Elist[i].E += Particles[pid].InternalEnergy;
+        Elist[i].Energy += Particles[pid].InternalEnergy;
 #endif
       }
       ESnap.SetMassUnit(1.); // reset, no necessary
@@ -556,7 +556,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     ParticleBindingEnergies.resize(Nbound);
 #pragma omp parallel for if (Nbound > 100)
     for (HBTInt i = 0; i < Nbound; i++)
-      ParticleBindingEnergies[i] = Elist[i].E;
+      ParticleBindingEnergies[i] = Elist[i].Energy;
   }
 
   /* Store the potential energy information to save later */

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -337,7 +337,7 @@ HBTReal GetMassUpscaleFactor(const EnergySnapshot_t &ESnap, const HBTInt &NLast,
    * so we use the particle number ratio. Hydrodynamical simulations likely use 
    * particles of different masses, so we need to accumulate particle masses*/
 #ifdef DM_ONLY
-  HBTReal MassUpscaleFactor = (HBTReal)Nlast / MaxSampleSize;
+  HBTReal MassUpscaleFactor = (HBTReal)NLast / MaxSampleSize;
 #else
   HBTReal MassParticleSubsample = 0;
 #pragma omp parallel for if (MaxSampleSize > 100) reduction(+:MassParticleSubsample)

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -14,10 +14,12 @@ struct ParticleEnergy_t
   HBTInt ParticleIndex;
   float E;
 };
+
 inline bool CompareEnergy(const ParticleEnergy_t &a, const ParticleEnergy_t &b)
 {
   return (a.E < b.E);
 };
+
 static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size_t len)
 /*sort Elist to move unbound particles to the end*/
 { // similar to the C++ partition() func
@@ -62,6 +64,7 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
     *iterbackward = *iterforward;
   }
 }
+
 static void PopMostBoundParticle(ParticleEnergy_t *Edata, const HBTInt Nbound)
 {
   HBTInt imin = 0;
@@ -73,6 +76,7 @@ static void PopMostBoundParticle(ParticleEnergy_t *Edata, const HBTInt Nbound)
   if (imin != 0)
     swap(Edata[imin], Edata[0]);
 }
+
 class EnergySnapshot_t : public Snapshot_t
 {
   HBTInt GetParticle(HBTInt i) const
@@ -86,27 +90,33 @@ public:
   HBTInt N;
   const ParticleList_t &Particles;
   HBTReal MassFactor;
+
   EnergySnapshot_t(ParticleEnergy_t *e, HBTInt n, const ParticleList_t &particles, const Snapshot_t &epoch)
     : Elist(e), N(n), Particles(particles), MassFactor(1.)
   {
     Cosmology = epoch.Cosmology;
   };
+
   void SetMassUnit(HBTReal mass_unit)
   {
     MassFactor = mass_unit;
   }
+
   HBTInt size() const
   {
     return N;
   }
+
   HBTInt GetId(HBTInt i) const
   {
     return Particles[GetParticle(i)].Id;
   }
+
   HBTReal GetMass(HBTInt i) const
   {
     return Particles[GetParticle(i)].Mass * MassFactor;
   }
+
   HBTReal GetInternalEnergy(HBTInt i) const
   {
 #ifdef HAS_THERMAL_ENERGY
@@ -115,6 +125,7 @@ public:
     return 0.;
 #endif
   }
+
   HBTReal GetPotentialEnergy(HBTInt i, const HBTxyz &refPos, const HBTxyz &refVel) const
   {
     // Load the total binding energy of the particle, then remove the thermal
@@ -137,14 +148,17 @@ public:
     }
     return E;
   }
+
   const HBTxyz GetPhysicalVelocity(HBTInt i) const
   {
     return Particles[GetParticle(i)].GetPhysicalVelocity();
   }
+
   const HBTxyz &GetComovingPosition(HBTInt i) const
   {
     return Particles[GetParticle(i)].ComovingPosition;
   }
+
   double AverageVelocity(HBTxyz &CoV, HBTInt NumPart)
   /*mass weighted average velocity*/
   {
@@ -177,6 +191,7 @@ public:
     CoV[2] = svz / msum;
     return msum;
   }
+
   double AveragePosition(HBTxyz &CoM, HBTInt NumPart)
   /*mass weighted average position*/
   {
@@ -230,6 +245,7 @@ public:
     CoM[2] = sz;
     return msum;
   }
+
   void AverageKinematics(float &SpecificPotentialEnergy, float &SpecificKineticEnergy, float SpecificAngularMomentum[3],
                          HBTInt NumPart, const HBTxyz &refPos, const HBTxyz &refVel)
   /*obtain specific potential, kinetic energy, and angular momentum for the first NumPart particles
@@ -281,6 +297,7 @@ public:
     SpecificAngularMomentum[2] = AMz / M;
   }
 };
+
 inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, GravityTree_t &tree, HBTxyz &RefPos,
                                      HBTxyz &RefVel)
 { // reorder the first Size particles according to their self-binding energy
@@ -312,6 +329,7 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
     }
   }
 }
+
 void Subhalo_t::Unbind(const Snapshot_t &epoch)
 { // the reference frame (pos and vel) should already be initialized before unbinding.
 
@@ -550,6 +568,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
       ParticlePotentialEnergies[i] = ESnap.GetPotentialEnergy(i, RefPos, RefVel);
   }
 }
+
 void Subhalo_t::RecursiveUnbind(SubhaloList_t &Subhalos, const Snapshot_t &snap)
 {
   /* Unbind all subhaloes that are nested deeper in the hierarchy of the current

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -65,18 +65,6 @@ static HBTInt PartitionBindingEnergy(vector<ParticleEnergy_t> &Elist, const size
   }
 }
 
-static void PopMostBoundParticle(ParticleEnergy_t *Edata, const HBTInt Nbound)
-{
-  HBTInt imin = 0;
-  for (HBTInt i = 1; i < Nbound; i++)
-  {
-    if (Edata[i].Energy < Edata[imin].Energy)
-      imin = i;
-  }
-  if (imin != 0)
-    swap(Edata[imin], Edata[0]);
-}
-
 class EnergySnapshot_t : public Snapshot_t
 {
   HBTInt GetParticle(HBTInt i) const

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -401,8 +401,8 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 
   /* This vector stores the original ordering of particles, and will later store
    * their binding energies. */
-  vector<ParticleEnergy_t> Elist(Nbound);
-  for (HBTInt i = 0; i < Nbound; i++)
+  vector<ParticleEnergy_t> Elist(Particles.size());
+  for (HBTInt i = 0; i < Particles.size(); i++)
     Elist[i].ParticleIndex = i;
 
   EnergySnapshot_t ESnap(Elist.data(), Elist.size(), Particles, epoch);

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -14,7 +14,7 @@ struct ParticleEnergy_t
   HBTInt ParticleIndex;
   float E;
 };
-inline bool CompEnergy(const ParticleEnergy_t &a, const ParticleEnergy_t &b)
+inline bool CompareEnergy(const ParticleEnergy_t &a, const ParticleEnergy_t &b)
 {
   return (a.E < b.E);
 };
@@ -299,7 +299,7 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
                                        RefVel, Particles[pid].Mass);
     }
 #pragma omp single
-    sort(Einner.begin(), Einner.end(), CompEnergy);
+    sort(Einner.begin(), Einner.end(), CompareEnergy);
 #pragma omp for
     for (HBTInt i = 0; i < Size; i++)
     {
@@ -458,7 +458,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     }
     else
     {
-      sort(Elist.begin() + Nbound, Elist.begin() + Nlast, CompEnergy); // only sort the unbound part
+      sort(Elist.begin() + Nbound, Elist.begin() + Nlast, CompareEnergy); // only sort the unbound part
       HBTInt Ndiff = Nlast - Nbound;
       if (Ndiff < Nbound)
       {
@@ -484,7 +484,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
           SinkTrackId = SpecialConst::NullTrackId; // clear sinktrack as well
         }
         // update particle list
-        sort(Elist.begin(), Elist.begin() + Nbound, CompEnergy); // sort the self-bound part
+        sort(Elist.begin(), Elist.begin() + Nbound, CompareEnergy); // sort the self-bound part
 
         /* We need to refine the most bound particle, as subsampling large subhaloes will lead to
          * incorrect ordering of binding energies. Hence, the most bound particle before this step

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -11,7 +11,7 @@
 
 struct ParticleEnergy_t
 {
-  HBTInt pid;
+  HBTInt ParticleIndex;
   float E;
 };
 inline bool CompEnergy(const ParticleEnergy_t &a, const ParticleEnergy_t &b)
@@ -77,7 +77,7 @@ class EnergySnapshot_t : public Snapshot_t
 {
   HBTInt GetParticle(HBTInt i) const
   {
-    return Elist[i].pid;
+    return Elist[i].ParticleIndex;
   }
 
 public:
@@ -293,8 +293,8 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
 #pragma omp for
     for (HBTInt i = 0; i < Size; i++)
     {
-      HBTInt pid = Elist[i].pid;
-      Einner[i].pid = i;
+      HBTInt pid = Elist[i].ParticleIndex;
+      Einner[i].ParticleIndex = i;
       Einner[i].E = tree.BindingEnergy(Particles[pid].ComovingPosition, Particles[pid].GetPhysicalVelocity(), RefPos,
                                        RefVel, Particles[pid].Mass);
     }
@@ -303,7 +303,7 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
 #pragma omp for
     for (HBTInt i = 0; i < Size; i++)
     {
-      Einner[i] = Elist[Einner[i].pid];
+      Einner[i] = Elist[Einner[i].ParticleIndex];
     }
 #pragma omp for
     for (HBTInt i = 0; i < Size; i++)
@@ -362,7 +362,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 
   vector<ParticleEnergy_t> Elist(Nbound);
   for (HBTInt i = 0; i < Nbound; i++)
-    Elist[i].pid = i;
+    Elist[i].ParticleIndex = i;
   EnergySnapshot_t ESnap(Elist.data(), Elist.size(), Particles, epoch);
   bool CorrectionLoop = false;
   while (true)
@@ -378,7 +378,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 #pragma omp parallel for if (Nlast > 100)
       for (HBTInt i = 0; i < Nbound; i++)
       {
-        HBTInt pid = Elist[i].pid;
+        HBTInt pid = Elist[i].ParticleIndex;
         auto &x = Particles[pid].ComovingPosition;
         auto v = Particles[pid].GetPhysicalVelocity();
         HBTxyz OldVel;
@@ -400,7 +400,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 #pragma omp parallel for if (Nlast > 100)
       for (HBTInt i = 0; i < Nlast; i++)
       {
-        HBTInt pid = Elist[i].pid;
+        HBTInt pid = Elist[i].ParticleIndex;
         HBTReal mass;
         if (i < np_tree)
           mass = ESnap.GetMass(i); // to correct for self-gravity
@@ -427,7 +427,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
     HBTInt Nbound_tracers = 0;
     for (HBTInt i = 0; i < Nbound; i += 1)
     {
-      const auto &p = Particles[Elist[i].pid];
+      const auto &p = Particles[Elist[i].ParticleIndex];
       if (p.IsTracer())
         Nbound_tracers += 1;
       if (Nbound_tracers >= HBTConfig.MinNumTracerPartOfSub)
@@ -505,8 +505,8 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
         ParticleList_t p(Particles.size());
         for (HBTInt i = 0; i < Particles.size(); i++)
         {
-          p[i] = Particles[Elist[i].pid];
-          Elist[i].pid = i; // update particle index in Elist as well.
+          p[i] = Particles[Elist[i].ParticleIndex];
+          Elist[i].ParticleIndex = i; // update particle index in Elist as well.
         }
         Particles.swap(p);
 


### PR DESCRIPTION
This PR changes the calculation of the factor by which the mass of subsampled particles is increased for potential calculations. It was based on the number of total particles divided by number of subsampled particles, which assumes equal-mass particles.

I have changed the calculations for hydrodynamical simulations so that it is based on the total _mass_ of particles divided by the _mass_ of subsampled particles. The DMO calculations remain the same. I also made some other changes to organise the unbinding code a bit.