### PR TITLE
Option to determine mass upscale factor per particle type.

### DIFF
--- a/examples/configs/Example.conf
+++ b/examples/configs/Example.conf
@@ -130,6 +130,16 @@ MaxSampleSizeOfPotentialEstimate 1000
 # unspecified can be subsampled if the subhalo is large enough.
 DoNotSubsampleParticleTypes 5
 
+# The manner in which the masses of subsampled particles are scaled to conserve
+# mass. A value of 0 applies a single mass upscale factor regardless of particle
+# type, which means that total mass is conserved but not the relative mass 
+# contributions of each subsampled particle type. A value of 1 applies an upscale
+# factor to each particle type independently, so that the total mass of each  
+# particle type is (APPROXIMATELY) conserved in the subsampled set. Mass conservation
+# of a given particle type will not be possible if said type is missing from the
+# subsampled set
+PotentialEstimateUpscaleMassesPerType 1
+
 # If the self-binding energy of the most bound subset of particles should be
 # computed after unbinding the subhalo. This step is done to better identify the
 # most bound particle if potential subsampling was enabled. Not enabling this

--- a/examples/configs/Example.conf
+++ b/examples/configs/Example.conf
@@ -123,6 +123,13 @@ SourceSubRelaxFactor 3
 # MaxSampleSizeOfPotentialEstimate particles are used as gravity sources.
 MaxSampleSizeOfPotentialEstimate 1000
 
+# Particle types which will never be subsampled during unbinding. The option is
+# provided for situations where particles can have a large mass difference 
+# relative to all other particles (e.g. black holes) or if the spatial 
+# distribution is significantly different (e.g. stars). Particle types left 
+# unspecified can be subsampled if the subhalo is large enough.
+DoNotSubsampleParticleTypes 5
+
 # If the self-binding energy of the most bound subset of particles should be
 # computed after unbinding the subhalo. This step is done to better identify the
 # most bound particle if potential subsampling was enabled. Not enabling this
@@ -131,7 +138,7 @@ RefineMostBoundParticle 1
 
 # Fraction of the most bound particles whose self-binding energies are computed
 # to better estimate the most bound particle. The actual value is
-# max(MaxSampleSizeOfPotentialEstimate, BoundFractionCenterRefinement).
+# max(MaxSampleSizeOfPotentialEstimate, BoundFractionCenterRefinement * Nbound).
 BoundFractionCenterRefinement 0.1
 
 [=============================== SUBHALO TRACKING =============================]
@@ -141,13 +148,6 @@ BoundFractionCenterRefinement 0.1
 # between subhaloes, and the position/velocity of orphan (disrupted) subhaloes.
 # We recommend using time-persistent, collisionless particles (e.g. DM & stars).
 TracerParticleTypes 1 4
-
-# Particle types which will never be subsampled during unbinding. The option is
-# provided for situations where particles can have a large mass difference 
-# relative to all other particles (e.g. black holes) or if the spatial 
-# distribution is significantly different (e.g. stars). Particle types left 
-# unspecified can be subsampled if the subhalo is large enough.
-DoNotSubsampleParticleTypes 5
 
 # Minimum number of bound particles required for a subhalo to be resolved,
 # regardless of their particle type.

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -506,7 +506,7 @@ void Parameter_t::DumpParameters()
   }
   version_file << "#VERSION " << HBT_VERSION << endl;
 
-#define DumpPar(var) version_file << #var << "  " << var << endl;
+#define DumpPar(var) version_file << #var << " " << var << endl;
 #define DumpComment(var)                                                                                               \
   {                                                                                                                    \
     version_file << "#";                                                                                               \

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -57,6 +57,7 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
   TrySetPar(SaveBoundParticleBindingEnergies);
   TrySetPar(SaveBoundParticlePotentialEnergies);
   TrySetPar(MergeTrappedSubhalos);
+  TrySetPar(PotentialEstimateUpscaleMassesPerType);
   TrySetPar(MajorProgenitorMassRatio);
   TrySetPar(BoundMassPrecision);
   TrySetPar(SourceSubRelaxFactor);
@@ -446,6 +447,7 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
   _SyncBool(SaveBoundParticleBindingEnergies);
   _SyncBool(SaveBoundParticlePotentialEnergies);
   _SyncBool(MergeTrappedSubhalos);
+  _SyncBool(PotentialEstimateUpscaleMassesPerType);
   _SyncVec(SnapshotIdList, MPI_INT);
   world.SyncVectorString(SnapshotNameList, root);
 
@@ -586,6 +588,7 @@ void Parameter_t::DumpParameters()
   if (RefineMostBoundParticle)
     DumpPar(BoundFractionCenterRefinement);
   DumpPar(MaxSampleSizeOfPotentialEstimate);
+  DumpPar(PotentialEstimateUpscaleMassesPerType);
 
   DumpHeader("Subhalo Tracking");
   DumpPar(MinNumPartOfSub);

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -589,6 +589,13 @@ void Parameter_t::DumpParameters()
     DumpPar(BoundFractionCenterRefinement);
   DumpPar(MaxSampleSizeOfPotentialEstimate);
   DumpPar(PotentialEstimateUpscaleMassesPerType);
+  if (DoNotSubsampleParticleTypes.size())
+  {
+    version_file << "DoNotSubsampleParticleTypes";
+    for (auto &&i : DoNotSubsampleParticleTypes)
+      version_file << " " << i;
+    version_file << endl;
+  }
 
   DumpHeader("Subhalo Tracking");
   DumpPar(MinNumPartOfSub);
@@ -599,13 +606,6 @@ void Parameter_t::DumpParameters()
   {
     version_file << "TracerParticleTypes";
     for (auto &&i : TracerParticleTypes)
-      version_file << " " << i;
-    version_file << endl;
-  }
-  if (DoNotSubsampleParticleTypes.size())
-  {
-    version_file << "DoNotSubsampleParticleTypes";
-    for (auto &&i : DoNotSubsampleParticleTypes)
       version_file << " " << i;
     version_file << endl;
   }

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -57,6 +57,8 @@ public:
   bool SaveBoundParticleBindingEnergies;
   bool SaveBoundParticlePotentialEnergies;
   bool MergeTrappedSubhalos; // whether to MergeTrappedSubhalos, see code paper for more info.
+  bool PotentialEstimateUpscaleMassesPerType;
+
   vector<int> SnapshotIdList;
   vector<int> TracerParticleTypes;
   vector<int> DoNotSubsampleParticleTypes; /* Which particles types cannot be subsampled. */
@@ -127,6 +129,7 @@ public:
     TreeNodeOpenAngle = 0.45;
     TreeMinNumOfCells = 10;
     MaxSampleSizeOfPotentialEstimate = 1000; // set to 0 to disable sampling
+    PotentialEstimateUpscaleMassesPerType = 1;
     RefineMostBoundParticle = true;
     BoundFractionCenterRefinement = 0.1; /* Default values chosen based on tests */
     GroupLoadedFullParticle = false;

--- a/src/mymath.h
+++ b/src/mymath.h
@@ -282,4 +282,24 @@ extern void logspace(double xmin, double xmax, int N, vector<float> &x);
 extern void EigenAxis(double Ixx, double Ixy, double Ixz, double Iyy, double Iyz, double Izz, float Axis[3][3]);
 #endif
 
+/* Sums two vectors in an elementwise manner and returns resulting vector. */
+template <class T>
+vector<T> SumElementwise(const vector<T> &x, const vector<T> &y)
+{
+  assert(x.size() == y.size());
+ 
+  vector<T> OutputVector(x.size(), 0);
+  for(int index = 0; index < OutputVector.size();  index++)
+    OutputVector[index] = x[index] + y[index];
+  return OutputVector;
+}
+
+/* OMP implementations for the above function, one for HBTInt and another 
+ * for HBTReal. */
+#pragma omp declare reduction(SumVectorElementwise: std::vector<HBTInt> : omp_out = SumElementwise(omp_out, omp_in))                     \
+initializer(omp_priv = decltype(omp_orig)(omp_orig.size(), 0))
+
+#pragma omp declare reduction(SumVectorElementwise: std::vector<HBTReal> : omp_out = SumElementwise(omp_out, omp_in))                     \
+initializer(omp_priv = decltype(omp_orig)(omp_orig.size(), 0))
+
 #endif

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -52,7 +52,7 @@ class EnergySnapshot_t : public Snapshot_t
     return Elist[i].ParticleIndex;
   }
 
-  vector<HBTReal> MassFactor;
+  vector<HBTReal> MassUpscaleFactor;
 
 public:
   ParticleEnergy_t *Elist;
@@ -61,7 +61,7 @@ public:
   const ParticleList_t &Particles;
 
   EnergySnapshot_t(ParticleEnergy_t *e, HBTInt n, const ParticleList_t &particles, const Snapshot_t &epoch)
-    : Elist(e), N(n), Particles(particles), MassFactor(TypeMax, 1.)
+    : Elist(e), N(n), Particles(particles), MassUpscaleFactor(TypeMax, 1.)
   {
     Cosmology = epoch.Cosmology;
   };
@@ -91,7 +91,7 @@ public:
     if(IsNotSubsampleParticleType(Particles[GetParticle(i)]))
       return Particles[GetParticle(i)].Mass;
     else
-      return Particles[GetParticle(i)].Mass * MassFactor[GetType(i)];
+      return Particles[GetParticle(i)].Mass * MassUpscaleFactor[GetType(i)];
   }
 
   /* Internal energy of the ith most bound particle. */
@@ -343,7 +343,7 @@ public:
    * particle. */
   void ResetMassUpscaleFactor()
   {
-    std::fill(MassFactor.begin(), MassFactor.end(), 1.);
+    std::fill(MassUpscaleFactor.begin(), MassUpscaleFactor.end(), 1.);
   }
 
   /* Upscales the masses of particles when they are subsampled for potential
@@ -351,9 +351,9 @@ public:
   void SetMassUpscaleFactor(const HBTInt &Nlast, const HBTReal &Mlast, const HBTInt &MaxSampleSize, const HBTInt &Nunsample)
   {
     if(HBTConfig.PotentialEstimateUpscaleMassesPerType)
-      MassFactor = GetMassUpscaleFactorPerParticleType(Nlast, Mlast, MaxSampleSize, Nunsample);
+      MassUpscaleFactor = GetMassUpscaleFactorPerParticleType(Nlast, Mlast, MaxSampleSize, Nunsample);
     else
-      MassFactor = GetMassUpscaleFactor(Nlast, Mlast, MaxSampleSize, Nunsample);
+      MassUpscaleFactor = GetMassUpscaleFactor(Nlast, Mlast, MaxSampleSize, Nunsample);
   }
 
 };

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -147,18 +147,6 @@ public:
     return Particles[GetParticle(i)].ComovingPosition;
   }
 
-  /* Computes the total mass of the first NumPart most bound particles. */
-  double SumUpMass(HBTInt NumPart)
-  {
-    double msum = 0;
-#pragma omp parallel for reduction(+ : msum) if (NumPart > 100)
-    for (HBTInt i = 0; i < NumPart; i++)
-    {
-      msum += GetMass(i);
-    }
-    return msum;
-  }
-
   /* Mass-weighted average velocity */
   double AverageVelocity(HBTxyz &CoV, HBTInt NumPart)
   {
@@ -280,7 +268,7 @@ public:
 
   /* Accumulates and returns the total mass per particle type between the Nstart 
    * and Nfinish most bound particle types. */
-  std::vector<HBTReal> GetMboundType(const HBTInt &Nstart, const HBTInt &Nfinish)
+  std::vector<HBTReal> AccumulateMassPerType(const HBTInt &Nstart, const HBTInt &Nfinish)
   {
     std::vector<HBTReal> MboundType = std::vector<HBTReal>(TypeMax, 0);
 #pragma omp parallel for reduction(SumVectorElementwise:MboundType) if ((Nfinish - Nstart) > 1000)
@@ -293,7 +281,7 @@ public:
 
   /* Accumulates and returns the total mass of particles between the Nstart and 
    * Nfinish most bound particle types. */
-   HBTReal GetMbound(const HBTInt &Nstart, const HBTInt &Nfinish)
+   HBTReal AccumulateMass(const HBTInt &Nstart, const HBTInt &Nfinish)
    {
     HBTReal Mbound = 0;
 #pragma omp parallel for reduction(+:Mbound) if ((Nfinish - Nstart) > 1000)
@@ -506,7 +494,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
   EnergySnapshot_t ESnap(Elist.data(), Elist.size(), Particles, epoch);
 
   /* Associated mass of the starting number of particles. */
-  Mbound = ESnap.SumUpMass(Nbound);
+  Mbound = ESnap.AccumulateMass(0, Nbound);
 
   /* Used to determine when iterative unbinding has converged to within the 
    * specified accuracy. */

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -46,6 +46,8 @@ static HBTInt RemoveUnboundParticles(vector<ParticleEnergy_t> &Elist, const size
 
 class EnergySnapshot_t : public Snapshot_t
 {
+
+  /* Index in the Particles vector of the ith most bound particle. */
   HBTInt GetParticle(HBTInt i) const
   {
     return Elist[i].ParticleIndex;
@@ -65,14 +67,22 @@ public:
     Cosmology = epoch.Cosmology;
   };
 
+  /* Used within the gravitational tree construction. */
   HBTInt size() const
   {
     return N;
   }
 
+  /* Particle ID of the ith most bound particle. */
   HBTInt GetId(HBTInt i) const
   {
     return Particles[GetParticle(i)].Id;
+  }
+
+  /* Particle type of the ith most bound particle. */
+  HBTInt GetType(HBTInt i) const
+  {
+    return Particles[GetParticle(i)].Type;
   }
 
   /* Sets how much more massive subsampled particles are. */
@@ -81,7 +91,7 @@ public:
     MassFactor = factor;
   }
 
-  /* Returns the (scaled) mass of a particle. It will be larger than the true
+  /* Scaled mass of the ith most bound particle. It will be larger than the true
    * mass if the particles are being subsampled. */
   HBTReal GetMass(HBTInt i) const
   {
@@ -91,6 +101,7 @@ public:
       return Particles[GetParticle(i)].Mass * MassFactor;
   }
 
+  /* Internal energy of the ith most bound particle. */
   HBTReal GetInternalEnergy(HBTInt i) const
   {
 #ifdef HAS_THERMAL_ENERGY
@@ -100,6 +111,7 @@ public:
 #endif
   }
 
+  /* Potential energy of the ith most bound particle. */
   HBTReal GetPotentialEnergy(HBTInt i, const HBTxyz &refPos, const HBTxyz &refVel) const
   {
     // Load the total binding energy of the particle, then remove the thermal
@@ -123,11 +135,13 @@ public:
     return E;
   }
 
+  /* Physical velocity of the ith most bound particle. */
   const HBTxyz GetPhysicalVelocity(HBTInt i) const
   {
     return Particles[GetParticle(i)].GetPhysicalVelocity();
   }
 
+  /* Comoving position of the ith most bound particle. */
   const HBTxyz &GetComovingPosition(HBTInt i) const
   {
     return Particles[GetParticle(i)].ComovingPosition;

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -350,8 +350,7 @@ std::vector<HBTReal> GetMboundType(const std::vector<ParticleEnergy_t> &Elist, c
 #pragma omp parallel for reduction(SumVectorElementwise:MboundType) if ((Nfinish - Nstart) > 1000)
   for (HBTInt i = Nstart; i < Nfinish; i++)
   {
-    auto &particle = Particles[Elist[i].ParticleIndex];
-    MboundType[particle.Type] += particle.Mass;
+    MboundType[Elist.GetType()] += Elist.GetMass();
   }
   return MboundType;
 }

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -336,6 +336,18 @@ public:
       if(MassPerTypeSubsample[type])
         MassUpscaleFactor[type] = MassPerTypeTotal[type] / MassPerTypeSubsample[type];
 
+    /* Ensure total mass conservation if we are missing a particle type from 
+     * our subsampled set. */
+    float TotalScaledMass = 0, TotalTrueMass = 0;
+    for(int type = 0; type < TypeMax; type++)
+    {
+      TotalTrueMass += MassPerTypeTotal[type];
+      TotalScaledMass += MassPerTypeSubsample[type] * MassUpscaleFactor[type];
+    }
+
+    for(int type = 0; type < TypeMax; type++)
+      MassUpscaleFactor[type] *= TotalTrueMass / TotalScaledMass;
+
     return MassUpscaleFactor;
   }
 

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -350,12 +350,10 @@ public:
    * calculation purposes. */
   void SetMassUpscaleFactor(const HBTInt &Nlast, const HBTReal &Mlast, const HBTInt &MaxSampleSize, const HBTInt &Nunsample)
   {
-    ResetMassUpscaleFactor(); /* To get true particle mass */
-
     if(HBTConfig.PotentialEstimateUpscaleMassesPerType)
-      MassFactor = GetMassUpscaleFactor(Nlast, Mlast, MaxSampleSize, Nunsample);
-    else
       MassFactor = GetMassUpscaleFactorPerParticleType(Nlast, Mlast, MaxSampleSize, Nunsample);
+    else
+      MassFactor = GetMassUpscaleFactor(Nlast, Mlast, MaxSampleSize, Nunsample);
   }
 
 };

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -30,6 +30,7 @@ foreach(TEST_NAME
     test_build_pos_vel
     test_argsort
     test_sort_by_hash
+    test_omp_vector_reductions
   )
 
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp $<TARGET_OBJECTS:hbtfuncs> $<TARGET_OBJECTS:testfuncs>)

--- a/unit_tests/test_omp_vector_reductions.cpp
+++ b/unit_tests/test_omp_vector_reductions.cpp
@@ -1,0 +1,55 @@
+#include <vector>
+#include <random>
+
+#include "verify.h"
+#include "mymath.h"
+
+int main(int argc, char *argv[])
+{
+  // Set up repeatable RNG
+  std::mt19937 rng;
+  rng.seed(0);
+
+  /* How many tests we will do and number of vectors per test. */
+  const int nr_reps = 1000;
+  const int number_vectors = 1000;
+
+  /* Dimensionality of each vector in a given test. */
+  const int min_dimension = 2, max_dimension = 10;
+  std::uniform_int_distribution<int> number_dimensions(min_dimension, max_dimension);
+
+  /* Maximum numerical value allowed in an individual vector entry */
+  const int max_value = 1000;
+  std::uniform_int_distribution<int> random_values(0, max_value);
+
+  for (int rep_nr = 0; rep_nr < nr_reps; rep_nr += 1)
+  {
+    /* How many dimensions we have in the current test. */
+    int vector_dimensions = number_dimensions(rng);
+
+    /* Vector of vectors which we will randomly populate and later sum 
+     * elementwise. */
+    std::vector<std::vector<HBTInt>> TestVector(number_vectors);
+    for(int i = 0; i < number_vectors; i++)
+    {
+      TestVector[i].reserve(vector_dimensions);
+      for(int j = 0; j < vector_dimensions; j++)
+        TestVector[i][j] = random_values(rng);
+    }
+
+    /* Results based on single thread. */
+    std::vector<HBTInt> ResultSingleThread(vector_dimensions,0);
+    for(int i = 0; i < number_vectors; i++)
+      ResultSingleThread = SumElementwise(ResultSingleThread, TestVector[i]); 
+
+    /* Results based on OMP implementation */
+    std::vector<HBTInt> ResultMultipleThread(vector_dimensions,0);
+#pragma omp parallel for reduction(SumVectorElementwise : ResultMultipleThread)
+    for(int i = 0; i < number_vectors; i++)
+      ResultMultipleThread = SumElementwise(ResultMultipleThread, TestVector[i]); 
+
+    for (int i = 0; i < vector_dimensions; i++)
+      verify(ResultMultipleThread[i]== ResultSingleThread[i]);
+  }
+  return 0;
+}


### PR DESCRIPTION
We currently define a mass upscale factor that is common to all particle types eligible to be subsampled. We agreed to implement and test a method that computes the factor on a _per particle type basis_. This PR does just that.