### PR TITLE
Change reserve to resize in vector reduction test

### DIFF
--- a/unit_tests/test_omp_vector_reductions.cpp
+++ b/unit_tests/test_omp_vector_reductions.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
     std::vector<std::vector<HBTInt>> TestVector(number_vectors);
     for(int i = 0; i < number_vectors; i++)
     {
-      TestVector[i].reserve(vector_dimensions);
+      TestVector[i].resize(vector_dimensions);
       for(int j = 0; j < vector_dimensions; j++)
         TestVector[i][j] = random_values(rng);
     }


### PR DESCRIPTION
This fixes a test failure I encountered while updating #81 from master.