### PR TITLE
Proper opening and closing of timing file.

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -18,15 +18,17 @@ using namespace std;
 
 int main(int argc, char **argv)
 {
+
   MPI_Init(&argc, &argv);
   MpiWorker_t world(MPI_COMM_WORLD);
+
 #ifdef _OPENMP
   // omp_set_nested(0);
   omp_set_max_active_levels(1); // max_active_level 0: no para; 1: single layer; >1: nest enabled
 #endif
 
   int snapshot_start, snapshot_end;
-  if (0 == world.rank())
+  if (world.rank() == 0)
   {
     // Print information about the version being run.
     cout << "HBT-HERONS compiled using git branch: " << branch_name << " and commit: " << commit_hash;
@@ -61,14 +63,6 @@ int main(int argc, char **argv)
 
   if (world.rank() == 0)
     cout << endl;
-
-  /* Create the timing log file */
-  ofstream time_log;
-  if (world.rank() == 0)
-  {
-    time_log.open(HBTConfig.SubhaloPath + "/timing.log", fstream::out | fstream::app);
-    time_log << fixed << setprecision(3);
-  }
 
   /* Main loop, iterate over chosen data outputs */
   for (int isnap = snapshot_start; isnap <= snapshot_end; isnap++)
@@ -165,28 +159,37 @@ int main(int argc, char **argv)
     merger_tree.FindDescendants(subsnap.Subhalos, world);
     global_timer.Tick("merger_tree", world.Communicator);
 
-    /* Save */
+    /* Save subhaloes */
     subsnap.Save(world);
     global_timer.Tick("write_subhalos", world.Communicator);
 
-    /* Output timing information */
     if (world.rank() == 0)
     {
-      // To report on how long the snapshot took to analyse in total
-      double total_time = 0;
+      /* Create or open the timing log file */
+      std::ofstream TimeLog;
+      TimeLog.open(HBTConfig.SubhaloPath + "/timing.log", std::fstream::out | std::fstream::app);
+      TimeLog << std::fixed << std::setprecision(3);
 
-      time_log << isnap << " \t" << subsnap.GetSnapshotId();
+      /* To report on how long the snapshot took to analyse in total. Only rank 0
+       * will print, so no need to synchronise. */
+      double TotalTime = 0;
+
+      /* Append line */
+      TimeLog << subsnap.GetSnapshotIndex() << " \t" << subsnap.GetSnapshotId();
       for (int i = 1; i < global_timer.Size(); i++)
       {
-        time_log << "\t" << global_timer.names[i] << "=" << global_timer.GetSeconds(i);
-        total_time += global_timer.GetSeconds(i);
+        TimeLog << "\t" << global_timer.names[i] << "=" << global_timer.GetSeconds(i);
+        TotalTime += global_timer.GetSeconds(i);
       }
-      time_log << endl;
+      TimeLog << std::endl;
 
-      cout << "SnapshotIndex " << isnap << " done. It took " << total_time << " seconds." << endl;
-      cout << endl;
+      /* Done. */
+      TimeLog.close();
+      global_timer.Reset();
+
+      std::cout << "SnapshotIndex " << subsnap.GetSnapshotIndex()  << " done. It took " << TotalTime << " seconds." << std::endl;
+      std::cout << std::endl;
     }
-    global_timer.Reset();
   }
 
   MPI_Finalize();

--- a/src/io/gadget_group_io.cpp
+++ b/src/io/gadget_group_io.cpp
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
   MpiWorker_t world(MPI_COMM_WORLD);
 
   int snapshot_start, snapshot_end;
-  if (0 == world.rank())
+  if (world.rank() == 0)
     ParseHBTParams(argc, argv, HBTConfig, snapshot_start, snapshot_end);
   HBTConfig.BroadCast(world, 0, snapshot_start, snapshot_end);
 

--- a/src/io/halo_io.cpp
+++ b/src/io/halo_io.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
   MpiWorker_t world(MPI_COMM_WORLD);
 
   int snapshot_start, snapshot_end;
-  if (0 == world.rank())
+  if (world.rank() == 0)
     ParseHBTParams(argc, argv, HBTConfig, snapshot_start, snapshot_end);
   HBTConfig.BroadCast(world, 0, snapshot_start, snapshot_end);
 

--- a/src/test/test_parse.cpp
+++ b/src/test/test_parse.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
 #endif
 
   int snapshot_start, snapshot_end;
-  if (0 == world.rank())
+  if (world.rank() == 0)
   {
     ParseHBTParams(argc, argv, HBTConfig, snapshot_start, snapshot_end);
     mkdir(HBTConfig.SubhaloPath.c_str(), 0755);


### PR DESCRIPTION
Fix resulting from the discussion in #105. The `timing.log` file was not updated after a line was deleted, which was due to the fact that HBT-HERONS opened the file at the beginning of the run and never closed it.
