### PR TITLE
Reset global timer for all mpi ranks

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -185,11 +185,12 @@ int main(int argc, char **argv)
 
       /* Done. */
       TimeLog.close();
-      global_timer.Reset();
 
       std::cout << "SnapshotIndex " << subsnap.GetSnapshotIndex()  << " done. It took " << TotalTime << " seconds." << std::endl;
       std::cout << std::endl;
     }
+    global_timer.Reset();
+
   }
 
   MPI_Finalize();


### PR DESCRIPTION
Fixes bug identified after merging #106 