### PR TITLE
Add default initialisation for ParticleNullGroupId

### DIFF
--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -137,6 +137,8 @@ public:
     GroupLoadedFullParticle = false;
     MaxPhysicalSofteningHalo = -1; // Indicates no max. physical softening is used.
 
+    ParticleNullGroupId = -1; /* Value of FoF group corresponding to no FoF */
+
     /* Tracer-related parameters. If unset, only use collisionless particles (DM
      * + Stars) as tracer. Here we assume they correspond to particle types 1
      * and 4, respectively. */


### PR DESCRIPTION
We did not set this value because it was loaded from `Swift` snapshots directly. However, this value is important to keep even for simulations that do not use the same FoF group information format, as we use it in `Subhalo_t::RemoveOtherHostParticles` to clean up particles that exist across two or more FoF groups. 