### PR TITLE
Variable core size

### DIFF
--- a/examples/configs/Example.conf
+++ b/examples/configs/Example.conf
@@ -50,7 +50,7 @@ GroupFileFormat
 ParticleNullGroupId
 
 # If particles split in the simulation, in which case their splitting history
-# needs to be provided. This is only implemented for SWIFT hydrodynamical 
+# needs to be provided. This is only implemented for SWIFT hydrodynamical
 # simulations.
 ParticlesSplit
 
@@ -124,17 +124,17 @@ SourceSubRelaxFactor 3
 MaxSampleSizeOfPotentialEstimate 1000
 
 # Particle types which will never be subsampled during unbinding. The option is
-# provided for situations where particles can have a large mass difference 
-# relative to all other particles (e.g. black holes) or if the spatial 
-# distribution is significantly different (e.g. stars). Particle types left 
+# provided for situations where particles can have a large mass difference
+# relative to all other particles (e.g. black holes) or if the spatial
+# distribution is significantly different (e.g. stars). Particle types left
 # unspecified can be subsampled if the subhalo is large enough.
 DoNotSubsampleParticleTypes 5
 
 # The manner in which the masses of subsampled particles are scaled to conserve
 # mass. A value of 0 applies a single mass upscale factor regardless of particle
-# type, which means that total mass is conserved but not the relative mass 
+# type, which means that total mass is conserved but not the relative mass
 # contributions of each subsampled particle type. A value of 1 applies an upscale
-# factor to each particle type independently, so that the total mass of each  
+# factor to each particle type independently, so that the total mass of each
 # particle type is (APPROXIMATELY) conserved in the subsampled set. Mass conservation
 # of a given particle type will not be possible if said type is missing from the
 # subsampled set

--- a/examples/configs/Example.conf
+++ b/examples/configs/Example.conf
@@ -185,12 +185,10 @@ MergeTrappedSubhalos 1
 # FoF. Expressed relative to the most massive subhalo in said host FoF group.
 MajorProgenitorMassRatio 0.8
 
-# Keeping here as a reference as it is defined, but it is not used internally at
-# the moment. It will be good to add as an additional option when computing the
-# phase-space distance between overlapping subhaloes. The current behaviour is
-# equivalent to SubCoreSizeMin = 10 and SubCoreSizeFactor=0.
-# SubCoreSizeMin 20
-# SubCoreSizeFactor 0.25
+# These parameters determine how many partices we use to define the core of a
+# self-bound subhalo, and hence its phase-space coordinates.
+SubCoreSizeMin 20
+SubCoreSizeFactor 0.
 
 [================================ MISCELLANEOUS ===============================]
 

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -122,7 +122,7 @@ bool Parameter_t::TryMultipleValueParameter(string ParameterName, stringstream &
     for (int i; ParameterValues >> i;)
       DoNotSubsampleParticleTypes.push_back(i);
 
-    /* Create a bitmask, to be used internally by the code to identify which 
+    /* Create a bitmask, to be used internally by the code to identify which
      * particles it should not subsample during unbinding. */
     DoNotSubsampleParticleBitMask = 0;
 
@@ -336,7 +336,7 @@ void Parameter_t::CheckValidityParameters()
     if (MaxSnapshotIndex != (SnapshotIdList.size() - 1))
     {
       error_message << "MaxSnapshotIndex (" << MaxSnapshotIndex << "): inconsistent with SnapshotIdList (SnapshotIdList.size() - 1 = " << (SnapshotIdList.size() - 1) << ")." << endl;
-      throw invalid_argument(error_message.str());      
+      throw invalid_argument(error_message.str());
     }
   }
 
@@ -347,7 +347,21 @@ void Parameter_t::CheckValidityParameters()
     throw invalid_argument(error_message.str());
   }
 
-  /* Cannot say we subsample in DMO and then disable DM particle subsampling. 
+  /* We always need at least one particle for core properties of self-bound subhaloes. */
+  if(SubCoreSizeMin < 1)
+  {
+    error_message << "SubCoreSizeMin: the minimum allowed value is 1. Increase the value of SubCoreSizeMin. " << endl;
+    throw invalid_argument(error_message.str());
+  }
+
+  /* No negative values for SubCoreSizeFactor allowed. */
+  if(SubCoreSizeFactor < 0)
+  {
+    error_message << "SubCoreSizeFactor: Negative values are not allowed. Use a value of 0 (no scaling with subhalo mass) or larger." << endl;
+    throw invalid_argument(error_message.str());
+  }
+
+  /* Cannot say we subsample in DMO and then disable DM particle subsampling.
    * Conversely, we cannot subsample in hydro and then disable subsampling for all
    * relevant particle types */
   {
@@ -357,7 +371,7 @@ void Parameter_t::CheckValidityParameters()
     vector<int> TestParticleTypes = {0, 1, 4, 5};
 #endif
 
-    /* Create a bit mask corresponding to disabling subsampling for all relevant types */    
+    /* Create a bit mask corresponding to disabling subsampling for all relevant types */
     int TestBitMask = 0;
     for (int i : TestParticleTypes)
       TestBitMask += 1 << i;
@@ -375,7 +389,7 @@ void Parameter_t::CheckValidityParameters()
   }
 }
 
-/* Checks if the input parameter file contains all required parameters and that 
+/* Checks if the input parameter file contains all required parameters and that
  * they have valid values. */
 void Parameter_t::CheckParameters()
 {

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -125,7 +125,7 @@ public:
     MajorProgenitorMassRatio = 0.8;
     BoundMassPrecision = 0.995;
     SourceSubRelaxFactor = 3.;
-    SubCoreSizeFactor = 0.25;
+    SubCoreSizeFactor = 0;
     SubCoreSizeMin = 20;
     TreeAllocFactor = 0.8; /* a value of 2 should be more than sufficient*/
     TreeNodeOpenAngle = 0.45;
@@ -153,7 +153,7 @@ public:
     DoNotSubsampleParticleBitMask = 0;
     for (int i : DoNotSubsampleParticleTypes)
       DoNotSubsampleParticleBitMask += 1 << i;
- 
+
     /* The value is negative to indicate whether the parameter has been set in the. If not,
      * we will default to a value of 1 if this is a swift HYDRO run. This way we reminder the
      * user to pre-process snapshots (toolbox/swiftsim/generate_splitting_information.py) */

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -600,3 +600,11 @@ vector<HBTInt> Subhalo_t::GetMostBoundTracerIds(HBTInt n)
 
   return Ids;
 }
+
+/* Returns number of tracer particles that are used to estimate the phase-space
+ * position of a given subhalo. Relevant for determininig if two more subhaloes
+ * overlap in phase space. */
+HBTInt Subhalo_t::GetCoreSize()
+{
+  return std::max(Nbound * HBTConfig.SubCoreSizeFactor, HBTConfig.SubCoreSizeMin);
+}

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -606,5 +606,5 @@ vector<HBTInt> Subhalo_t::GetMostBoundTracerIds(HBTInt n)
  * overlap in phase space. */
 HBTInt Subhalo_t::GetCoreSize()
 {
-  return std::max(Nbound * HBTConfig.SubCoreSizeFactor, HBTConfig.SubCoreSizeMin);
+  return std::max(static_cast<HBTInt>(Nbound * HBTConfig.SubCoreSizeFactor), HBTConfig.SubCoreSizeMin);
 }

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -332,6 +332,10 @@ public:
   /* To remove duplicate particles from the source subgroup. */
   void CleanTracks();
 
+  /* To determine number of most bound tracer particles used to estimate the
+   * position and velocity of the subhalo.*/
+  HBTInt GetCoreSize();
+
   HBTInt size() const
   {
     return Subhalos.size();
@@ -353,21 +357,6 @@ public:
     return Subhalos[index].GetMass();
   }
 };
-
-inline HBTInt GetCoreSize(HBTInt nbound)
-/* get the size of the core that determines the position of the subhalo.
- * coresize controlled by SubCoreSizeFactor and SubCoreSizeMin.
- * if you do not want a cored center, then
- * set SubCoreSizeFactor=0 and SubCoreSizeMin=1 to use most-bound particle;
- * set SubCoreSizeFactor=1 to use all the particles*/
-{
-  int coresize = nbound * HBTConfig.SubCoreSizeFactor;
-  if (coresize < HBTConfig.SubCoreSizeMin)
-    coresize = HBTConfig.SubCoreSizeMin;
-  if (coresize > nbound)
-    coresize = nbound;
-  return coresize;
-}
 
 class TrackKeyList_t : public KeyList_t<HBTInt, HBTInt>
 {

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -203,6 +203,12 @@ public:
 #endif
   }
   vector<HBTInt> GetMostBoundTracerIds(HBTInt n);
+
+private:
+  /* To determine number of most bound tracer particles used to estimate the
+   * position and velocity of the subhalo.*/
+   HBTInt GetCoreSize();
+
 };
 
 class MemberShipTable_t
@@ -331,10 +337,6 @@ public:
 
   /* To remove duplicate particles from the source subgroup. */
   void CleanTracks();
-
-  /* To determine number of most bound tracer particles used to estimate the
-   * position and velocity of the subhalo.*/
-  HBTInt GetCoreSize();
 
   HBTInt size() const
   {

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -8,7 +8,6 @@
 #include "snapshot_number.h"
 #include "subhalo.h"
 
-#define NumPartCoreMax 20
 #define PhaseSpaceDistanceThreshold 2.
 
 /* Computes distance in phase space between the current subhalo and a reference
@@ -111,6 +110,9 @@ void Subhalo_t::GetCorePhaseSpaceProperties()
   vector<double> pos(3, 0), pos2(3, 0);
   vector<double> vel(3, 0), vel2(3, 0);
 
+  /* How many particles we will use */
+  HBTInt CoreSize = GetCoreSize();
+
   // Use first particle as reference point for box wrap
   vector<double> origin(3, 0);
   if (HBTConfig.PeriodicBoundaryOn)
@@ -148,11 +150,11 @@ void Subhalo_t::GetCorePhaseSpaceProperties()
           vel2[dim] += m * dv * dv;
         }
       }
-      if (NumPart == NumPartCoreMax)
+      if (NumPart == CoreSize)
         break;
       /* Next particle in subhalo */
     }
-    if (NumPart == NumPartCoreMax)
+    if (NumPart == CoreSize)
       break;
     /* Next pass */
   }


### PR DESCRIPTION
HBT-HERONS had the number of tracer particles that it uses for merger-related calculations hard coded. 

This PR makes it a runtime variable, which by default reproduces the same behaviour as before.