### PR TITLE
NO MORE using namespace std;

### DIFF
--- a/HBT.cpp
+++ b/HBT.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <cstdlib>
 #include <iostream>
 #include <omp.h>
@@ -31,30 +30,30 @@ int main(int argc, char **argv)
   if (world.rank() == 0)
   {
     // Print information about the version being run.
-    cout << "HBT-HERONS compiled using git branch: " << branch_name << " and commit: " << commit_hash;
+    std::cout << "HBT-HERONS compiled using git branch: " << branch_name << " and commit: " << commit_hash;
     if (uncommitted_changes)
-      cout << " (with uncommitted changes)";
+      std::cout << " (with uncommitted changes)";
     else
-      cout << " (clean)";
-    cout << endl;
+      std::cout << " (clean)";
+    std::cout << std::endl;
 
     ParseHBTParams(argc, argv, HBTConfig, snapshot_start, snapshot_end);
     mkdir(HBTConfig.SubhaloPath.c_str(), 0755);
 
-    cout << argv[0] << " run using " << world.size() << " mpi tasks";
+    std::cout << argv[0] << " run using " << world.size() << " mpi tasks";
 #ifdef _OPENMP
 #pragma omp parallel
 #pragma omp master
-    cout << ", each with " << omp_get_num_threads() << " threads";
-    cout << endl;
+    std::cout << ", each with " << omp_get_num_threads() << " threads";
+    std::cout << std::endl;
 #endif
-    cout << endl;
-    cout << "Configured with the following data type sizes (bytes):" << endl;
-    cout << "  Real quantities    : " << sizeof(HBTReal) << endl;
-    cout << "  Integer quantities : " << sizeof(HBTInt) << endl;
-    cout << "  Particle velocities: " << sizeof(HBTVelType) << endl;
-    cout << "  Particle masses    : " << sizeof(HBTMassType) << endl;
-    cout << "  Size of Particle_t : " << sizeof(Particle_t) << endl;
+    std::cout << std::endl;
+    std::cout << "Configured with the following data type sizes (bytes):" << std::endl;
+    std::cout << "  Real quantities    : " << sizeof(HBTReal) << std::endl;
+    std::cout << "  Integer quantities : " << sizeof(HBTInt) << std::endl;
+    std::cout << "  Particle velocities: " << sizeof(HBTVelType) << std::endl;
+    std::cout << "  Particle masses    : " << sizeof(HBTMassType) << std::endl;
+    std::cout << "  Size of Particle_t : " << sizeof(Particle_t) << std::endl;
   }
   HBTConfig.BroadCast(world, 0, snapshot_start, snapshot_end);
 
@@ -62,7 +61,7 @@ int main(int argc, char **argv)
   subsnap.Load(world, snapshot_start - 1, SubReaderDepth_t::SrcParticles);
 
   if (world.rank() == 0)
-    cout << endl;
+    std::cout << std::endl;
 
   /* Main loop, iterate over chosen data outputs */
   for (int isnap = snapshot_start; isnap <= snapshot_end; isnap++)
@@ -134,7 +133,7 @@ int main(int argc, char **argv)
     /* Assign gas particles to the same subhalo as their nearest neighbour
        tracer type particle in the same FoF group */
     if (world.rank() == 0)
-      cout << "Reassigning particles...\n";
+      std::cout << "Reassigning particles...\n";
     subsnap.ReassignParticles(world, halosnap);
     global_timer.Tick("reassign_particles", world.Communicator);
 

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -10,7 +10,7 @@ namespace PhysicalConst
 
 Parameter_t HBTConfig;
 
-bool Parameter_t::TryCompulsoryParameterValue(string ParameterName, stringstream &ParameterValue)
+bool Parameter_t::TryCompulsoryParameterValue(std::string ParameterName, std::stringstream &ParameterValue)
 {
 #define TrySetPar(var, i)                                                                                              \
   if (ParameterName == #var)                                                                                           \
@@ -33,7 +33,7 @@ bool Parameter_t::TryCompulsoryParameterValue(string ParameterName, stringstream
   return false; // This signals to continue looking for valid parameter names
 }
 
-bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &ParameterValue)
+bool Parameter_t::TrySingleValueParameter(std::string ParameterName, std::stringstream &ParameterValue)
 {
 #define TrySetPar(var)                                                                                                 \
   if (ParameterName == #var)                                                                                           \
@@ -82,15 +82,15 @@ bool Parameter_t::TrySingleValueParameter(string ParameterName, stringstream &Pa
 
   if (ParameterName == "GroupParticleIdMask")
   {
-    ParameterValue >> hex >> GroupParticleIdMask >> dec;
-    cout << "GroupParticleIdMask = " << hex << GroupParticleIdMask << dec << endl;
+    ParameterValue >> std::hex >> GroupParticleIdMask >> std::dec;
+    std::cout << "GroupParticleIdMask = " << std::hex << GroupParticleIdMask << std::dec << std::endl;
     return true;
   }
 
   return false; // This signals to continue looking for valid parameter names
 }
 
-bool Parameter_t::TryMultipleValueParameter(string ParameterName, stringstream &ParameterValues)
+bool Parameter_t::TryMultipleValueParameter(std::string ParameterName, std::stringstream &ParameterValues)
 {
 
   if (ParameterName == "SnapshotIdList")
@@ -133,9 +133,9 @@ bool Parameter_t::TryMultipleValueParameter(string ParameterName, stringstream &
       /* Sanity check: we can only specify a single number if -1 is present. */
       if(DoNotSubsampleParticleTypes.size() > 1)
       {
-        stringstream error_message;
-        error_message << "DoNotSubsampleParticleTypes only takes a single number if -1 is present. " << endl;
-        throw runtime_error(error_message.str());
+        std::stringstream error_message;
+        error_message << "DoNotSubsampleParticleTypes only takes a single number if -1 is present. " << std::endl;
+        throw std::runtime_error(error_message.str());
       }
 
       /* We need a right bit shift, as it is otherwise undefined. */
@@ -150,13 +150,12 @@ bool Parameter_t::TryMultipleValueParameter(string ParameterName, stringstream &
   return false; // This signals to continue looking for valid parameter names
 }
 
-void Parameter_t::SetParameterValue(const string &line)
+void Parameter_t::SetParameterValue(const std::string &line)
 {
   /* Get the name of the parameter */
-  stringstream ss(line);
-  string name;
+  std::stringstream ss(line);
+  std::string name;
   ss >> name;
-  //   transform(name.begin(),name.end(),name.begin(),::tolower);
 
   /* We will try matching the name of the input parameter to those which have
    * been defined in the code. If we find a match, we assign its value. First
@@ -169,24 +168,24 @@ void Parameter_t::SetParameterValue(const string &line)
     return;
 
   /* No matching parameter name has been found, throw an error message */
-  stringstream error_message;
-  error_message << "Unrecognized configuration entry: " << name << endl;
-  throw runtime_error(error_message.str());
+  std::stringstream error_message;
+  error_message << "Unrecognized configuration entry: " << name << std::endl;
+  throw std::runtime_error(error_message.str());
 }
 
 void Parameter_t::ParseConfigFile(const char *param_file)
 {
-  ifstream ifs;
+  std::ifstream ifs;
   ifs.open(param_file);
   if (!ifs.is_open()) // or ifs.fail()
   {
-    cerr << "Error: failed to open configuration: " << param_file << endl;
+    std::cerr << "Error: failed to open configuration: " << param_file << std::endl;
     exit(1);
   }
-  vector<string> lines;
-  string line;
+  std::vector<std::string> lines;
+  std::string line;
 
-  cout << "Reading configuration file " << param_file << endl;
+  std::cout << "Reading configuration file " << param_file << std::endl;
 
   while (getline(ifs, line))
   {
@@ -220,23 +219,22 @@ void Parameter_t::ParseConfigFile(const char *param_file)
 void Parameter_t::ReadSnapshotNameList()
 { // to specify snapshotnamelist, create a file "snapshotlist.txt" under SubhaloPath, and list the filenames inside, one
   // per line.
-  string snaplist_filename = SubhaloPath + "/snapshotlist.txt";
-  ifstream ifs;
+  std::string snaplist_filename = SubhaloPath + "/snapshotlist.txt";
+  std::ifstream ifs;
   ifs.open(snaplist_filename);
   if (ifs.is_open())
   {
-    cout << "Found SnapshotNameList file " << snaplist_filename << endl;
+    std::cout << "Found SnapshotNameList file " << snaplist_filename << std::endl;
 
-    string line;
+    std::string line;
     while (getline(ifs, line))
     {
       trim_trailing_garbage(line, "#");
-      istringstream ss(line);
-      string name;
+      std::istringstream ss(line);
+      std::string name;
       ss >> name;
       if (!name.empty())
       {
-        // 		cout<<name<<endl;
         SnapshotNameList.push_back(name);
       }
     }
@@ -248,42 +246,42 @@ void Parameter_t::ReadSnapshotNameList()
 /* Checks whether the all mandatory parameters have been specified */
 void Parameter_t::CheckRequiredParameters()
 {
-  stringstream error_message; /* In case we need to raise an error. */
+  std::stringstream error_message; /* In case we need to raise an error. */
 
   if(!IsSet[0])
   {
-    error_message << "SnapshotPath: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "SnapshotPath: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
   if(!IsSet[1])
   {
-    error_message << "HaloPath: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "HaloPath: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
   if(!IsSet[2])
   {
-    error_message << "SubhaloPath: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "SubhaloPath: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
   if(!IsSet[3])
   {
-    error_message << "SnapshotFileBase: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "SnapshotFileBase: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
   if(!IsSet[4])
   {
-    error_message << "MaxSnapshotIndex: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "MaxSnapshotIndex: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
   if(!IsSet[5])
   {
-    error_message << "BoxSize: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "BoxSize: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
   if(!IsSet[6])
   {
-    error_message << "SofteningHalo: Mandatory parameter not found." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "SofteningHalo: Mandatory parameter not found." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
 }
 
@@ -298,27 +296,27 @@ bool ContainsDuplicateValues(const std::vector<int> &InputVectorParameter)
 /* Checks whether the input parameters are valid */
 void Parameter_t::CheckValidityParameters()
 {
-  stringstream error_message; /* In case we need to raise an error. */
+  std::stringstream error_message; /* In case we need to raise an error. */
 
   /* Make sure we have not provided duplicate entries for vector input types */
   {
     /* SnapshotIdList will be empty if no values are passed at runtime. */
     if(SnapshotIdList.size() && ContainsDuplicateValues(SnapshotIdList))
     {
-      error_message << "SnapshotIdList: There are duplicate values, please remove repeated elements." << endl;
-      throw invalid_argument(error_message.str());
+      error_message << "SnapshotIdList: There are duplicate values, please remove repeated elements." << std::endl;
+      throw std::invalid_argument(error_message.str());
     }
 
     if(ContainsDuplicateValues(TracerParticleTypes))
     {
-      error_message << "TracerParticleTypes: There are duplicate values, please remove repeated elements." << endl;
-      throw invalid_argument(error_message.str());
+      error_message << "TracerParticleTypes: There are duplicate values, please remove repeated elements." << std::endl;
+      throw std::invalid_argument(error_message.str());
     }
 
     if(ContainsDuplicateValues(DoNotSubsampleParticleTypes))
     {
-      error_message << "DoNotSubsampleParticleTypes: There are duplicate values, please remove repeated elements." << endl;
-      throw invalid_argument(error_message.str());
+      error_message << "DoNotSubsampleParticleTypes: There are duplicate values, please remove repeated elements." << std::endl;
+      throw std::invalid_argument(error_message.str());
     }
   }
 
@@ -328,38 +326,38 @@ void Parameter_t::CheckValidityParameters()
     /* The snapshot ID list should be in ascending order. */
     if(!std::is_sorted(SnapshotIdList.begin(), SnapshotIdList.end()))
     {
-      error_message << "SnapshotIdList: Values are not in ascending order." << endl;
-      throw invalid_argument(error_message.str());
+      error_message << "SnapshotIdList: Values are not in ascending order." << std::endl;
+      throw std::invalid_argument(error_message.str());
     }
 
     /* MaxSnapshotIndex should be consistent with SnapshotIdList */
     if (MaxSnapshotIndex != (SnapshotIdList.size() - 1))
     {
-      error_message << "MaxSnapshotIndex (" << MaxSnapshotIndex << "): inconsistent with SnapshotIdList (SnapshotIdList.size() - 1 = " << (SnapshotIdList.size() - 1) << ")." << endl;
-      throw invalid_argument(error_message.str());
+      error_message << "MaxSnapshotIndex (" << MaxSnapshotIndex << "): inconsistent with SnapshotIdList (SnapshotIdList.size() - 1 = " << (SnapshotIdList.size() - 1) << ")." << std::endl;
+      throw std::invalid_argument(error_message.str());
     }
   }
 
   /* No negative values for MaxSampleSizeOfPotentialEstimate allowed. */
   if(MaxSampleSizeOfPotentialEstimate < 0)
   {
-    error_message << "MaxSampleSizeOfPotentialEstimate: Negative values are not allowed. Use a value of 0 (no subsampling) or larger (subsampling)." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "MaxSampleSizeOfPotentialEstimate: Negative values are not allowed. Use a value of 0 (no subsampling) or larger (subsampling)." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
 
   /* We always need at least one particle for core properties of self-bound subhaloes. */
   if(SubCoreSizeMin < 1)
   {
-    error_message << "SubCoreSizeMin: the minimum allowed value is 1. Increase the value of SubCoreSizeMin. " << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "SubCoreSizeMin: the minimum allowed value is 1. Increase the value of SubCoreSizeMin. " << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
 
   /* No negative values for SubCoreSizeFactor allowed and we cannot use more than
    * Nbound particles. */
   if((SubCoreSizeFactor < 0.) | (SubCoreSizeFactor > 1.))
   {
-    error_message << "SubCoreSizeFactor: allowed values are only within [0, 1], with 0 disabling the core size scaling with Nbound." << endl;
-    throw invalid_argument(error_message.str());
+    error_message << "SubCoreSizeFactor: allowed values are only within [0, 1], with 0 disabling the core size scaling with Nbound." << std::endl;
+    throw std::invalid_argument(error_message.str());
   }
 
   /* Cannot say we subsample in DMO and then disable DM particle subsampling.
@@ -367,9 +365,9 @@ void Parameter_t::CheckValidityParameters()
    * relevant particle types */
   {
 #ifdef DM_ONLY
-    vector<int> TestParticleTypes = {1};
+    std::vector<int> TestParticleTypes = {1};
 #else
-    vector<int> TestParticleTypes = {0, 1, 4, 5};
+    std::vector<int> TestParticleTypes = {0, 1, 4, 5};
 #endif
 
     /* Create a bit mask corresponding to disabling subsampling for all relevant types */
@@ -381,11 +379,11 @@ void Parameter_t::CheckValidityParameters()
     if (TestBitMask == DoNotSubsampleParticleBitMask)
     {
 #ifdef DM_ONLY
-      error_message << "Cannot enable subsampling (MaxSampleSizeOfPotentialEstimate > 0) and then disable subsampling (DoNotSubsampleParticleTypes 1) in DMO simulations. Disable either of the two options." << endl;
+      error_message << "Cannot enable subsampling (MaxSampleSizeOfPotentialEstimate > 0) and then disable subsampling (DoNotSubsampleParticleTypes 1) in DMO simulations. Disable either of the two options." << std::endl;
 #else
-      error_message << "Cannot enable subsampling (MaxSampleSizeOfPotentialEstimate > 0) and then disable subsampling (DoNotSubsampleParticleTypes 0 1 4 5) in HYDRO simulations. Disable either of the two options." << endl;
+      error_message << "Cannot enable subsampling (MaxSampleSizeOfPotentialEstimate > 0) and then disable subsampling (DoNotSubsampleParticleTypes 0 1 4 5) in HYDRO simulations. Disable either of the two options." << std::endl;
 #endif
-      throw invalid_argument(error_message.str());
+      throw std::invalid_argument(error_message.str());
     }
   }
 }
@@ -514,19 +512,19 @@ void Parameter_t::BroadCast(MpiWorker_t &world, int root)
 void Parameter_t::DumpParameters()
 {
 #ifndef HBT_VERSION
-  cout << "Warning: HBT_VERSION unknown.\n";
+  std::cout << "Warning: HBT_VERSION unknown.\n";
 #define HBT_VERSION "unknown"
 #endif
-  string filename = SubhaloPath + "/Parameters.log";
-  ofstream version_file(filename, ios::out | ios::trunc);
+  std::string filename = SubhaloPath + "/Parameters.log";
+  std::ofstream version_file(filename, std::ios::out | std::ios::trunc);
   if (!version_file.is_open())
   {
-    cerr << "Error opening " << filename << " for parameter dump." << endl;
+    std::cerr << "Error opening " << filename << " for parameter dump." << std::endl;
     exit(1);
   }
-  version_file << "#VERSION " << HBT_VERSION << endl;
+  version_file << "#VERSION " << HBT_VERSION << std::endl;
 
-#define DumpPar(var) version_file << #var << " " << var << endl;
+#define DumpPar(var) version_file << #var << " " << var << std::endl;
 #define DumpComment(var)                                                                                               \
   {                                                                                                                    \
     version_file << "#";                                                                                               \
@@ -534,8 +532,8 @@ void Parameter_t::DumpParameters()
   }
 #define DumpHeader(title)                                                                                              \
   {                                                                                                                    \
-    version_file << endl;                                                                                              \
-    version_file << "[" << title << "]" << endl;                                                                       \
+    version_file << std::endl;                                                                                              \
+    version_file << "[" << title << "]" << std::endl;                                                                       \
   }
 
   DumpHeader("File paths");
@@ -556,7 +554,7 @@ void Parameter_t::DumpParameters()
     version_file << "SnapshotIdList";
     for (auto &&i : SnapshotIdList)
       version_file << " " << i;
-    version_file << endl;
+    version_file << std::endl;
   }
 
   if (SnapshotNameList.size())
@@ -564,7 +562,7 @@ void Parameter_t::DumpParameters()
     version_file << "#SnapshotNameList";
     for (auto &&i : SnapshotNameList)
       version_file << " " << i;
-    version_file << endl;
+    version_file << std::endl;
   }
 
   DumpHeader("Particle Properties");
@@ -579,7 +577,7 @@ void Parameter_t::DumpParameters()
   DumpPar(ParticlesSplit);
 #endif
   if (GroupParticleIdMask)
-    version_file << "GroupParticleIdMask " << hex << GroupParticleIdMask << dec << endl;
+    version_file << "GroupParticleIdMask " << std::hex << GroupParticleIdMask << std::dec << std::endl;
 
   DumpHeader("Units");
   DumpPar(MassInMsunh);
@@ -614,7 +612,7 @@ void Parameter_t::DumpParameters()
     version_file << "DoNotSubsampleParticleTypes";
     for (auto &&i : DoNotSubsampleParticleTypes)
       version_file << " " << i;
-    version_file << endl;
+    version_file << std::endl;
   }
 
   DumpHeader("Subhalo Tracking");
@@ -627,7 +625,7 @@ void Parameter_t::DumpParameters()
     version_file << "TracerParticleTypes";
     for (auto &&i : TracerParticleTypes)
       version_file << " " << i;
-    version_file << endl;
+    version_file << std::endl;
   }
   DumpPar(MergeTrappedSubhalos);
   DumpPar(MajorProgenitorMassRatio);
@@ -647,5 +645,5 @@ HBTReal Parameter_t::GetCurrentSoftening(HBTReal ScaleFactor)
     return SofteningHalo;
 
   // If two are defined, choose the one with the smallest value
-  return min(SofteningHalo, MaxPhysicalSofteningHalo / ScaleFactor);
+  return std::min(SofteningHalo, MaxPhysicalSofteningHalo / ScaleFactor);
 }

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -24,20 +24,20 @@ class Parameter_t
 public:
   // remember to update SetParameterValue() and DumpParameters() accordingly if you change any parameter definition.
   /*compulsory parameters*/
-  string SnapshotPath;
-  string HaloPath;
-  string SubhaloPath;
-  string SnapshotFileBase;
+  std::string SnapshotPath;
+  std::string HaloPath;
+  std::string SubhaloPath;
+  std::string SnapshotFileBase;
   int MaxSnapshotIndex;
   HBTReal BoxSize; // to check the unit of snapshot according to the BoxSize in header
   HBTReal SofteningHalo;
   HBTReal MaxPhysicalSofteningHalo;
-  vector<bool> IsSet;
+  std::vector<bool> IsSet;
 
   /*optional*/
-  string SnapshotDirBase;
-  string SnapshotFormat;
-  string GroupFileFormat;
+  std::string SnapshotDirBase;
+  std::string SnapshotFormat;
+  std::string GroupFileFormat;
   int MaxConcurrentIO;
   int MinSnapshotIndex;
   int MinNumPartOfSub;
@@ -59,10 +59,10 @@ public:
   bool MergeTrappedSubhalos; // whether to MergeTrappedSubhalos, see code paper for more info.
   bool PotentialEstimateUpscaleMassesPerType;
 
-  vector<int> SnapshotIdList;
-  vector<int> TracerParticleTypes;
-  vector<int> DoNotSubsampleParticleTypes; /* Which particles types cannot be subsampled. */
-  vector<string> SnapshotNameList;
+  std::vector<int> SnapshotIdList;
+  std::vector<int> TracerParticleTypes;
+  std::vector<int> DoNotSubsampleParticleTypes; /* Which particles types cannot be subsampled. */
+  std::vector<std::string> SnapshotNameList;
 
   HBTReal MajorProgenitorMassRatio;
   HBTReal BoundMassPrecision;
@@ -142,14 +142,14 @@ public:
     /* Tracer-related parameters. If unset, only use collisionless particles (DM
      * + Stars) as tracer. Here we assume they correspond to particle types 1
      * and 4, respectively. */
-    TracerParticleTypes = vector<int>{1, 4};
+    TracerParticleTypes = std::vector<int>{1, 4};
     TracerParticleBitMask = 0;
     for (int i : TracerParticleTypes)
       TracerParticleBitMask += 1 << i;
 
     /* We default to not subsampling black holes, since they are generally very
      * massive relative to all other particle types. */
-    DoNotSubsampleParticleTypes = vector<int>{5};
+    DoNotSubsampleParticleTypes = std::vector<int>{5};
     DoNotSubsampleParticleBitMask = 0;
     for (int i : DoNotSubsampleParticleTypes)
       DoNotSubsampleParticleBitMask += 1 << i;
@@ -172,7 +172,7 @@ public:
   }
   void ReadSnapshotNameList();
   void ParseConfigFile(const char *param_file);
-  void SetParameterValue(const string &line);
+  void SetParameterValue(const std::string &line);
 
   /* Functions that will check if the input parameter file contains all required
    * parameters and that they have valid values. */
@@ -193,25 +193,25 @@ public:
   HBTReal GetCurrentSoftening(HBTReal ScaleFactor); // NOTE: perhaps makes more sense to include in gravity tree...
 
 private:
-  bool TryCompulsoryParameterValue(string ParameterName, stringstream &ParameterValue);
-  bool TrySingleValueParameter(string ParameterName, stringstream &ParameterValue);
-  bool TryMultipleValueParameter(string ParameterName, stringstream &ParameterValues);
+  bool TryCompulsoryParameterValue(std::string ParameterName, std::stringstream &ParameterValue);
+  bool TrySingleValueParameter(std::string ParameterName, std::stringstream &ParameterValue);
+  bool TryMultipleValueParameter(std::string ParameterName, std::stringstream &ParameterValues);
 };
 
 extern Parameter_t HBTConfig;
 extern void ParseHBTParams(int argc, char **argv, Parameter_t &config, int &snapshot_start, int &snapshot_end);
-inline void trim_leading_garbage(string &s, const string &garbage_list)
+inline void trim_leading_garbage(std::string &s, const std::string &garbage_list)
 {
   int pos = s.find_first_not_of(garbage_list); // look for any good staff
-  if (string::npos != pos)
+  if (std::string::npos != pos)
     s.erase(0, pos); // s=s.substr(pos);
   else               // no good staff, clear everything
     s.clear();
 }
-inline void trim_trailing_garbage(string &s, const string &garbage_list)
+inline void trim_trailing_garbage(std::string &s, const std::string &garbage_list)
 {
   int pos = s.find_first_of(garbage_list);
-  if (string::npos != pos)
+  if (std::string::npos != pos)
     s.erase(pos);
 }
 

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -5,11 +5,10 @@
 #include <iterator>
 #include <queue>
 #include <cassert>
-using namespace std;
+// using namespace std;
 #include <array>
 #include <vector>
 
-// #include <memory>
 #ifdef DM_ONLY
 #undef UNBIND_WITH_THERMAL_ENERGY
 #undef HAS_THERMAL_ENERGY
@@ -56,7 +55,7 @@ typedef float HBTVelType;
 typedef HBTReal HBTVelType;
 #define MPI_HBT_VEL MPI_HBT_REAL
 #endif
-typedef array<HBTVelType, 3> HBTvel;
+typedef std::array<HBTVelType, 3> HBTvel;
 
 // Type to store masses
 #ifdef HBT_REAL4_MASS
@@ -79,7 +78,7 @@ typedef int HBTInt;
 #endif
 
 /* Used for reducing the TracerIndex value. Taken from https://shorturl.at/aENT2 */
-typedef pair<HBTInt, int> IndexParticleType_t;
+typedef std::pair<HBTInt, int> IndexParticleType_t;
 inline IndexParticleType_t firstIndex(IndexParticleType_t a, IndexParticleType_t b)
 {
   return a.first < b.first ? a : b;
@@ -90,7 +89,7 @@ inline IndexParticleType_t firstIndex(IndexParticleType_t a, IndexParticleType_t
 {
   memcpy(dest, src, sizeof(HBTxyz));
 }*/
-typedef array<HBTReal, 3> HBTxyz;
+typedef std::array<HBTReal, 3> HBTxyz;
 inline void copyHBTxyz(HBTxyz &dest, const HBTxyz &src)
 {
   /*copy for std:arr implementation*/
@@ -238,7 +237,7 @@ class LocatedParticleCollector_t : public ParticleCollector_t
 // a simple collector that appends all found particles to a vector.
 {
 public:
-  vector<LocatedParticle_t> Founds;
+  std::vector<LocatedParticle_t> Founds;
   LocatedParticleCollector_t(HBTInt n_reserve = 0) : Founds()
   {
     Founds.reserve(n_reserve);

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -5,7 +5,6 @@
 #include <iterator>
 #include <queue>
 #include <cassert>
-// using namespace std;
 #include <array>
 #include <vector>
 

--- a/src/geometric_tree.cpp
+++ b/src/geometric_tree.cpp
@@ -216,7 +216,7 @@ void GeoTree_t::Search(const HBTxyz &searchcenter, HBTReal radius, ParticleColle
 double GeoTree_t::SphDensity(const HBTxyz &cen, HBTReal &hguess)
 {
   LocatedParticleCollector_t collector(NumNeighbourSPH * 2);
-  vector<LocatedParticle_t> &founds = collector.Founds;
+  std::vector<LocatedParticle_t> &founds = collector.Founds;
   Search(cen, hguess, collector);
   int numngb = founds.size();
   while (numngb < NumNeighbourSPH)

--- a/src/gravity_tree.cpp
+++ b/src/gravity_tree.cpp
@@ -208,7 +208,7 @@ int main(int argc, char **argv)
     double E =
       tree.BindingEnergy(snapshot.GetComovingPosition(P[i]), snapshot.GetPhysicalVelocity(P[i]),
                          halo.Halos[0].ComovingPosition, halo.Halos[0].PhysicalVelocity, snapshot.GetMass(P[i]));
-    cout << i << " : " << E << endl;
+    std::cout << i << " : " << E << std::endl;
   }
 
   return 0;

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -13,9 +13,6 @@
 #include "mymath.h"
 #include "particle_exchanger.h"
 
-// #include <cstdio>
-// #include <cstdlib>
-
 void create_MPI_Halo_Id_type(MPI_Datatype &MPI_HBTHalo_Id_t)
 {
   /*to create the struct containing only haloid*/
@@ -88,8 +85,8 @@ class HaloParticleKeyList_t : public KeyList_t<HBTInt, HBTInt>
 {
   typedef HBTInt Index_t;
   typedef HBTInt Key_t;
-  vector<HBTInt> ParticleIds;
-  vector<HBTInt> HaloIds; // local haloid
+  std::vector<HBTInt> ParticleIds;
+  std::vector<HBTInt> HaloIds; // local haloid
 public:
   HaloParticleKeyList_t(HaloSnapshot_t &snap)
   {
@@ -148,7 +145,7 @@ HBTInt Halo_t::KickNullParticles()
     if (it->Id != SpecialConst::NullParticleId) // there will be consumed particles
     {
       if (it != it_save)
-        *it_save = move(*it);
+        *it_save = std::move(*it);
       ++it_save;
     }
   }

--- a/src/halo.h
+++ b/src/halo.h
@@ -15,7 +15,7 @@
 class Halo_t
 {
 public:
-  typedef vector<Particle_t> ParticleList_t;
+  typedef std::vector<Particle_t> ParticleList_t;
   ParticleList_t Particles;
   HBTInt HaloId;
   HBTxyz ComovingAveragePosition;
@@ -39,7 +39,7 @@ extern void create_MPI_Halo_Id_type(MPI_Datatype &MPI_HBTHalo_Id_t);
 
 class HaloSnapshot_t : public Snapshot_t
 {
-  typedef vector<Halo_t> HaloList_t;
+  typedef std::vector<Halo_t> HaloList_t;
   MPI_Datatype MPI_HBT_HaloId_t; // MPI datatype ignoring the particle list
   void BuildMPIDataType();
 

--- a/src/halo_particle_iterator.h
+++ b/src/halo_particle_iterator.h
@@ -4,7 +4,7 @@
 template <class HaloIterator>
 class HaloParticleIterator_t
 {
-  typedef vector<Particle_t>::iterator particle_iterator;
+  typedef std::vector<Particle_t>::iterator particle_iterator;
   HaloIterator FirstHalo, EndHalo, CurrHalo;
   particle_iterator CurrPart;
 
@@ -58,7 +58,7 @@ template <class HaloIterator>
 class HaloNestIterator_t
 {
   typedef HBTInt NestMember_t;
-  typedef vector<NestMember_t>::iterator nest_iterator;
+  typedef std::vector<NestMember_t>::iterator nest_iterator;
   HaloIterator FirstHalo, EndHalo, CurrHalo;
   nest_iterator CurrPart;
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -3,7 +3,6 @@
 #ifndef HASH_HEADER_INCLUDED
 #define HASH_HEADER_INCLUDED
 
-// #include "datatypes.h"
 #include <exception>
 #include <string>
 
@@ -16,7 +15,7 @@ public:
   virtual Index_t size() const = 0;
 };
 
-class InvalidPIdException_t : public exception
+class InvalidPIdException_t : public std::exception
 {
 private:
   HBTInt PId;
@@ -28,7 +27,7 @@ public:
   };
   const char *what() const throw()
   {
-    stringstream msg;
+    std::stringstream msg;
     msg << "Invalid Particle Id " << PId << " for index lookup\n";
     return msg.str().c_str();
   };
@@ -95,8 +94,8 @@ public:
 private:
   HBTInt NumQueryCrit;
   typedef IndexTable_t<Key_t, Index_t> BaseClass_t;
-  vector<Pair_t> Map;
-  typedef typename vector<Pair_t>::const_iterator MapIter_t;
+  std::vector<Pair_t> Map;
+  typedef typename std::vector<Pair_t>::const_iterator MapIter_t;
   template <class ParticleIdList_T>
   void GetIndicesRecursive(ParticleIdList_T &particles, HBTInt imin, HBTInt imax, MapIter_t MapBegin,
                            MapIter_t MapEnd) const;

--- a/src/hash.tpp
+++ b/src/hash.tpp
@@ -33,7 +33,7 @@ void MappedIndexTable_t<Key_t, Index_t>::Fill(const KeyList_t<Key_t, Index_t> &K
 template <class Key_t, class Index_t>
 void MappedIndexTable_t<Key_t, Index_t>::Clear()
 {
-  vector<Pair_t>().swap(Map);
+  std::vector<Pair_t>().swap(Map);
   NumQueryCrit = 0;
 }
 template <class Key_t, class Index_t>

--- a/src/hdf_wrapper.h
+++ b/src/hdf_wrapper.h
@@ -3,7 +3,6 @@
 
 #include "hdf5.h"
 #include "hdf5_hl.h"
-// #include "H5Cpp.h"
 #include <iostream>
 #include <mpi.h>
 

--- a/src/io/apostle_io/apostle_io.cpp
+++ b/src/io/apostle_io/apostle_io.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <iostream>
 #include <numeric>
 #include <assert.h>
@@ -60,26 +59,26 @@ void ApostleReader_t::SetSnapshot(int snapshotId)
 {
   if (HBTConfig.SnapshotNameList.empty())
   {
-    stringstream formatter;
-    formatter << "snapshot_" << setw(3) << setfill('0') << snapshotId;
+    std::stringstream formatter;
+    formatter << "snapshot_" << std::setw(3) << std::setfill('0') << snapshotId;
     SnapshotName = formatter.str();
   }
   else
     SnapshotName = HBTConfig.SnapshotNameList[snapshotId];
 }
 
-void ApostleReader_t::GetFileName(int ifile, string &filename)
+void ApostleReader_t::GetFileName(int ifile, std::string &filename)
 {
-  string subname = SnapshotName;
+  std::string subname = SnapshotName;
   subname.erase(4, 4); // i.e., remove "shot" from "snapshot" or "snipshot"
-  stringstream formatter;
+  std::stringstream formatter;
   formatter << HBTConfig.SnapshotPath << "/" << SnapshotName << "/" << subname << "." << ifile << ".hdf5";
   filename = formatter.str();
 }
 
 void ApostleReader_t::ReadHeader(int ifile, ApostleHeader_t &header)
 {
-  string filename;
+  std::string filename;
   GetFileName(ifile, filename);
   hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   ReadAttribute(file, "Header", "NumFilesPerSnapshot", H5T_NATIVE_INT, &Header.NumberOfFiles);
@@ -89,7 +88,6 @@ void ApostleReader_t::ReadHeader(int ifile, ApostleHeader_t &header)
   ReadAttribute(file, "Header", "Omega0", H5T_NATIVE_DOUBLE, &Header.OmegaM0);
   ReadAttribute(file, "Header", "OmegaLambda", H5T_NATIVE_DOUBLE, &Header.OmegaLambda0);
   ReadAttribute(file, "Header", "MassTable", H5T_NATIVE_DOUBLE, Header.mass);
-  //   cout<<Header.mass[0]<<","<<Header.mass[1]<<","<<Header.mass[2]<<endl;
   ReadAttribute(file, "Header", "NumPart_ThisFile", H5T_NATIVE_INT, Header.npart);
 
   unsigned np[TypeMax], np_high[TypeMax];
@@ -118,12 +116,12 @@ HBTInt ApostleReader_t::CompileFileOffsets(int nfiles)
     offset_file.push_back(offset);
 
     int np_this[TypeMax];
-    string filename;
+    std::string filename;
     GetFileName(ifile, filename);
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
     GetParticleCountInFile(file, np_this);
     H5Fclose(file);
-    HBTInt np = accumulate(begin(np_this), end(np_this), (HBTInt)0);
+    HBTInt np = std::accumulate(std::begin(np_this), std::end(np_this), (HBTInt)0);
 
     np_file.push_back(np);
     offset += np;
@@ -142,11 +140,11 @@ static void check_id_size(hid_t loc)
 }
 void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
 {
-  string filename;
+  std::string filename;
   GetFileName(ifile, filename);
   hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-  vector<int> np_this(TypeMax);
-  vector<HBTInt> offset_this(TypeMax);
+  std::vector<int> np_this(TypeMax);
+  std::vector<HBTInt> offset_this(TypeMax);
   GetParticleCountInFile(file, np_this.data());
   CompileOffsets(np_this, offset_this);
 
@@ -158,7 +156,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
     if (np == 0)
       continue;
     auto ParticlesThisType = ParticlesInFile + offset_this[itype];
-    stringstream grpname;
+    std::stringstream grpname;
     grpname << "PartType" << itype;
     if (!H5Lexists(file, grpname.str().c_str(), H5P_DEFAULT))
       continue;
@@ -168,7 +166,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
     check_id_size(particle_data);
 
     { // read position
-      vector<HBTxyz> x(np);
+      std::vector<HBTxyz> x(np);
       ReadDataset(particle_data, "Coordinates", H5T_HBTReal, x.data());
       if (HBTConfig.PeriodicBoundaryOn)
       {
@@ -181,7 +179,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
     }
 
     { // velocity
-      vector<HBTxyz> v(np);
+      std::vector<HBTxyz> v(np);
       if (H5Lexists(particle_data, "Velocities", H5P_DEFAULT))
         ReadDataset(particle_data, "Velocities", H5T_HBTReal, v.data());
       else
@@ -192,7 +190,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
     }
 
     { // id
-      vector<HBTInt> id(np);
+      std::vector<HBTInt> id(np);
       ReadDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data());
       for (int i = 0; i < np; i++)
         ParticlesThisType[i].Id = id[i];
@@ -201,7 +199,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
     // mass
     if (Header.mass[itype] == 0)
     {
-      vector<HBTReal> m(np);
+      std::vector<HBTReal> m(np);
       if (H5Lexists(particle_data, "Masses", H5P_DEFAULT))
         ReadDataset(particle_data, "Masses", H5T_HBTReal, m.data());
       else
@@ -220,7 +218,7 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
 #ifdef HAS_THERMAL_ENERGY
     if (itype == 0)
     {
-      vector<HBTReal> u(np);
+      std::vector<HBTReal> u(np);
       ReadDataset(particle_data, "InternalEnergy", H5T_HBTReal, u.data());
       for (int i = 0; i < np; i++)
         ParticlesThisType[i].InternalEnergy = u[i];
@@ -247,11 +245,11 @@ void ApostleReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile)
 
 void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInFile, bool FlagReadParticleId)
 {
-  string filename;
+  std::string filename;
   GetFileName(ifile, filename);
   hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-  vector<int> np_this(TypeMax);
-  vector<HBTInt> offset_this(TypeMax);
+  std::vector<int> np_this(TypeMax);
+  std::vector<HBTInt> offset_this(TypeMax);
   GetParticleCountInFile(file, np_this.data());
   CompileOffsets(np_this, offset_this);
 
@@ -263,7 +261,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
     if (np == 0)
       continue;
     auto ParticlesThisType = ParticlesInFile + offset_this[itype];
-    stringstream grpname;
+    std::stringstream grpname;
     grpname << "PartType" << itype;
     if (!H5Lexists(file, grpname.str().c_str(), H5P_DEFAULT))
       continue;
@@ -272,7 +270,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
     if (FlagReadParticleId)
     {
       { // read position
-        vector<HBTxyz> x(np);
+        std::vector<HBTxyz> x(np);
         ReadDataset(particle_data, "Coordinates", H5T_HBTReal, x.data());
         if (HBTConfig.PeriodicBoundaryOn)
         {
@@ -285,7 +283,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
       }
 
       { // velocity
-        vector<HBTxyz> v(np);
+        std::vector<HBTxyz> v(np);
         if (H5Lexists(particle_data, "Velocities", H5P_DEFAULT))
           ReadDataset(particle_data, "Velocities", H5T_HBTReal, v.data());
         else
@@ -296,7 +294,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
       }
 
       { // id
-        vector<HBTInt> id(np);
+        std::vector<HBTInt> id(np);
         ReadDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data());
         for (int i = 0; i < np; i++)
           ParticlesThisType[i].Id = id[i];
@@ -305,7 +303,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
       // mass
       if (Header.mass[itype] == 0)
       {
-        vector<HBTReal> m(np);
+        std::vector<HBTReal> m(np);
         if (H5Lexists(particle_data, "Masses", H5P_DEFAULT))
           ReadDataset(particle_data, "Masses", H5T_HBTReal, m.data());
         else
@@ -324,7 +322,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
 #ifdef HAS_THERMAL_ENERGY
       if (itype == 0)
       {
-        vector<HBTReal> u(np);
+        std::vector<HBTReal> u(np);
         ReadDataset(particle_data, "InternalEnergy", H5T_HBTReal, u.data());
         for (int i = 0; i < np; i++)
           ParticlesThisType[i].InternalEnergy = u[i];
@@ -345,7 +343,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
     }
 
     { // Hostid
-      vector<HBTInt> id(np);
+      std::vector<HBTInt> id(np);
       ReadDataset(particle_data, "GroupNumber", H5T_HBTInt, id.data());
       for (int i = 0; i < np; i++)
         ParticlesThisType[i].HostId = (id[i] < 0 ? NullGroupId : id[i]); // negative means outside fof but within Rv
@@ -357,7 +355,7 @@ void ApostleReader_t::ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInF
   H5Fclose(file);
 }
 
-void ApostleReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles,
+void ApostleReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, std::vector<Particle_t> &Particles,
                                    Cosmology_t &Cosmology)
 {
   SetSnapshot(snapshotId);
@@ -401,14 +399,6 @@ void ApostleReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Pa
       }
     }
   }
-
-  //   cout<<endl;
-  //   cout<<" ( "<<Header.NumberOfFiles<<" total files ) : "<<Particles.size()<<" particles loaded."<<endl;
-  //   cout<<" Particle[0]: x="<<Particles[0].ComovingPosition<<", v="<<Particles[0].PhysicalVelocity<<",
-  //   m="<<Particles[0].Mass<<endl; cout<<" Particle[2]: x="<<Particles[2].ComovingPosition<<",
-  //   v="<<Particles[2].PhysicalVelocity<<", m="<<Particles[2].Mass<<endl; cout<<" Particle[end]:
-  //   x="<<Particles.back().ComovingPosition<<", v="<<Particles.back().PhysicalVelocity<<",
-  //   m="<<Particles.back().Mass<<endl;
 }
 
 inline bool CompParticleHost(const ParticleHost_t &a, const ParticleHost_t &b)
@@ -416,7 +406,7 @@ inline bool CompParticleHost(const ParticleHost_t &a, const ParticleHost_t &b)
   return a.HostId < b.HostId;
 }
 
-void ApostleReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo_t> &Halos)
+void ApostleReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, std::vector<Halo_t> &Halos)
 { // read in particle properties at the same time, to avoid particle look-up at later stage.
   SetSnapshot(snapshotId);
 
@@ -430,7 +420,7 @@ void ApostleReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo
   world.SyncContainer(np_file, MPI_HBT_INT, root);
   world.SyncContainer(offset_file, MPI_HBT_INT, root);
 
-  vector<ParticleHost_t> ParticleHosts;
+  std::vector<ParticleHost_t> ParticleHosts;
   HBTInt nfiles_skip, nfiles_end;
   AssignTasks(world.rank(), world.size(), Header.NumberOfFiles, nfiles_skip, nfiles_end);
   {
@@ -472,7 +462,7 @@ void ApostleReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo
     {
     }
   };
-  vector<HaloLen_t> HaloLen;
+  std::vector<HaloLen_t> HaloLen;
 
   HBTInt curr_host_id = NullGroupId;
   for (auto &&p : ParticleHosts)
@@ -508,7 +498,7 @@ void ApostleReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo
   global_timer.Tick("halo_comms", world.Communicator);
 }
 
-bool IsApostleGroup(const string &GroupFileFormat)
+bool IsApostleGroup(const std::string &GroupFileFormat)
 {
   return GroupFileFormat.substr(0, 7) == "apostle";
 }

--- a/src/io/apostle_io/apostle_io.h
+++ b/src/io/apostle_io/apostle_io.h
@@ -38,16 +38,16 @@ struct ParticleHost_t : public Particle_t
 class ApostleReader_t
 {
   const int NullGroupId = 1 << 30; // 1073741824
-  string SnapshotName;
+  std::string SnapshotName;
 
-  vector<HBTInt> np_file;
-  vector<HBTInt> offset_file;
+  std::vector<HBTInt> np_file;
+  std::vector<HBTInt> offset_file;
   ApostleHeader_t Header;
   void ReadHeader(int ifile, ApostleHeader_t &header);
   HBTInt CompileFileOffsets(int nfiles);
   void ReadSnapshot(int ifile, Particle_t *ParticlesInFile);
   void ReadGroupParticles(int ifile, ParticleHost_t *ParticlesInFile, bool FlagReadParticleId);
-  void GetFileName(int ifile, string &filename);
+  void GetFileName(int ifile, std::string &filename);
   void SetSnapshot(int snapshotId);
   void GetParticleCountInFile(hid_t file, int np[]);
 
@@ -62,9 +62,9 @@ public:
   {
     My_Type_free(&MPI_ApostleHeader_t);
   }
-  void LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles, Cosmology_t &Cosmology);
-  void LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo_t> &Halos);
+  void LoadSnapshot(MpiWorker_t &world, int snapshotId, std::vector<Particle_t> &Particles, Cosmology_t &Cosmology);
+  void LoadGroups(MpiWorker_t &world, int snapshotId, std::vector<Halo_t> &Halos);
 };
 
-extern bool IsApostleGroup(const string &GroupFileFormat);
+extern bool IsApostleGroup(const std::string &GroupFileFormat);
 #endif

--- a/src/io/comms/exchange_and_merge.cpp
+++ b/src/io/comms/exchange_and_merge.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <assert.h>
 #include <chrono>
 #include <cstdio>
@@ -72,7 +71,7 @@ inline bool CompHaloId(const Halo_t &a, const Halo_t &b)
   return a.HaloId < b.HaloId;
 }
 
-static double ReduceHaloPosition(vector<HaloInfo_t>::iterator it_begin, vector<HaloInfo_t>::iterator it_end, HBTxyz &x)
+static double ReduceHaloPosition(std::vector<HaloInfo_t>::iterator it_begin, std::vector<HaloInfo_t>::iterator it_end, HBTxyz &x)
 {
   HBTInt i, j;
   double sx[3], origin[3], msum;
@@ -116,8 +115,8 @@ static double ReduceHaloPosition(vector<HaloInfo_t>::iterator it_begin, vector<H
   return msum;
 }
 
-static void ReduceHaloRank(vector<HaloInfo_t>::iterator it_begin, vector<HaloInfo_t>::iterator it_end, HBTxyz &step,
-                           vector<int> &dims)
+static void ReduceHaloRank(std::vector<HaloInfo_t>::iterator it_begin, std::vector<HaloInfo_t>::iterator it_end, HBTxyz &step,
+                           std::vector<int> &dims)
 {
   HBTxyz x;
   ReduceHaloPosition(it_begin, it_end, x);
@@ -126,13 +125,13 @@ static void ReduceHaloRank(vector<HaloInfo_t>::iterator it_begin, vector<HaloInf
     it->id = rank; // store destination rank in id.
 }
 
-static void DecideTargetProcessor(MpiWorker_t &world, vector<Halo_t> &Halos, vector<IdRank_t> &TargetRank)
+static void DecideTargetProcessor(MpiWorker_t &world, std::vector<Halo_t> &Halos, std::vector<IdRank_t> &TargetRank)
 {
   int this_rank = world.rank();
   for (auto &&h : Halos)
     h.Mass = AveragePosition(h.ComovingAveragePosition, h.Particles.data(), h.Particles.size());
 
-  vector<HaloInfo_t> HaloInfoSend(Halos.size()), HaloInfoRecv;
+  std::vector<HaloInfo_t> HaloInfoSend(Halos.size()), HaloInfoRecv;
   for (HBTInt i = 0; i < Halos.size(); i++)
   {
     HaloInfoSend[i].id = Halos[i].HaloId;
@@ -147,7 +146,7 @@ static void DecideTargetProcessor(MpiWorker_t &world, vector<Halo_t> &Halos, vec
   HBTInt ndiv = (++MaxHaloId) / world.size();
   if (MaxHaloId % world.size())
     ndiv++;
-  vector<int> SendSizes(world.size(), 0), SendOffsets(world.size()), RecvSizes(world.size()), RecvOffsets(world.size());
+  std::vector<int> SendSizes(world.size(), 0), SendOffsets(world.size()), RecvSizes(world.size()), RecvOffsets(world.size());
   for (HBTInt i = 0; i < Halos.size(); i++)
   {
     int idiv = Halos[i].HaloId / ndiv;
@@ -163,8 +162,8 @@ static void DecideTargetProcessor(MpiWorker_t &world, vector<Halo_t> &Halos, vec
                 RecvSizes.data(), RecvOffsets.data(), MPI_HaloInfo_t, world.Communicator);
   for (int i = 0; i < nhalo_recv; i++)
     HaloInfoRecv[i].order = i;
-  sort(HaloInfoRecv.begin(), HaloInfoRecv.end(), CompHaloInfo_Id);
-  list<int> haloid_offsets;
+  std::sort(HaloInfoRecv.begin(), HaloInfoRecv.end(), CompHaloInfo_Id);
+  std::list<int> haloid_offsets;
   HBTInt curr_id = -1;
   for (int i = 0; i < nhalo_recv; i++)
   {
@@ -204,7 +203,7 @@ static void DecideTargetProcessor(MpiWorker_t &world, vector<Halo_t> &Halos, vec
 
 /* After communicating disjoint pieces of FoF groups from different MPI ranks,
  * merge them into a single FoF group. */
-static void MergeHalos(vector<Halo_t> &Halos)
+static void MergeHalos(std::vector<Halo_t> &Halos)
 {
   if (Halos.empty())
     return;
@@ -222,7 +221,7 @@ static void MergeHalos(vector<Halo_t> &Halos)
     {
       ++it1;
       if (it2 != it1)
-        *it1 = move(*it2);
+        *it1 = std::move(*it2);
     }
   }
   Halos.resize(it1 - Halos.begin() + 1);
@@ -239,24 +238,24 @@ static void MergeHalos(vector<Halo_t> &Halos)
   }
 }
 
-static void ExchangeHalos(MpiWorker_t &world, vector<Halo_t> &InHalos, vector<Halo_t> &OutHalos,
+static void ExchangeHalos(MpiWorker_t &world, std::vector<Halo_t> &InHalos, std::vector<Halo_t> &OutHalos,
                           MPI_Datatype MPI_Halo_Shell_Type)
 {
-  typedef typename vector<Halo_t>::iterator HaloIterator_t;
+  typedef typename std::vector<Halo_t>::iterator HaloIterator_t;
   typedef HaloParticleIterator_t<HaloIterator_t> ParticleIterator_t;
 
-  vector<IdRank_t> TargetRank(InHalos.size());
+  std::vector<IdRank_t> TargetRank(InHalos.size());
   DecideTargetProcessor(world, InHalos, TargetRank);
 
   // distribute halo shells
-  vector<int> SendHaloCounts(world.size(), 0), RecvHaloCounts(world.size()), SendHaloDisps(world.size()),
+  std::vector<int> SendHaloCounts(world.size(), 0), RecvHaloCounts(world.size()), SendHaloDisps(world.size()),
     RecvHaloDisps(world.size());
-  sort(TargetRank.begin(), TargetRank.end(), CompareRank);
-  vector<Halo_t> InHalosSorted(InHalos.size());
-  vector<HBTInt> InHaloSizes(InHalos.size());
+  std::sort(TargetRank.begin(), TargetRank.end(), CompareRank);
+  std::vector<Halo_t> InHalosSorted(InHalos.size());
+  std::vector<HBTInt> InHaloSizes(InHalos.size());
   for (HBTInt haloid = 0; haloid < InHalos.size(); haloid++)
   {
-    InHalosSorted[haloid] = move(InHalos[TargetRank[haloid].Id]);
+    InHalosSorted[haloid] = std::move(InHalos[TargetRank[haloid].Id]);
     SendHaloCounts[TargetRank[haloid].Rank]++;
     InHaloSizes[haloid] = InHalosSorted[haloid].Particles.size();
   }
@@ -268,7 +267,7 @@ static void ExchangeHalos(MpiWorker_t &world, vector<Halo_t> &InHalos, vector<Ha
   MPI_Alltoallv(InHalosSorted.data(), SendHaloCounts.data(), SendHaloDisps.data(), MPI_Halo_Shell_Type, &NewHalos[0],
                 RecvHaloCounts.data(), RecvHaloDisps.data(), MPI_Halo_Shell_Type, world.Communicator);
   // resize receivehalos
-  vector<HBTInt> OutHaloSizes(NumNewHalos);
+  std::vector<HBTInt> OutHaloSizes(NumNewHalos);
   MPI_Alltoallv(InHaloSizes.data(), SendHaloCounts.data(), SendHaloDisps.data(), MPI_HBT_INT, OutHaloSizes.data(),
                 RecvHaloCounts.data(), RecvHaloDisps.data(), MPI_HBT_INT, world.Communicator);
   for (HBTInt i = 0; i < NumNewHalos; i++)
@@ -279,8 +278,8 @@ static void ExchangeHalos(MpiWorker_t &world, vector<Halo_t> &InHalos, vector<Ha
     MPI_Datatype MPI_HBT_Particle;
     Particle_t().create_MPI_type(MPI_HBT_Particle);
     // create combined iterator for each bunch of haloes
-    vector<ParticleIterator_t> InParticleIterator(world.size());
-    vector<ParticleIterator_t> OutParticleIterator(world.size());
+    std::vector<ParticleIterator_t> InParticleIterator(world.size());
+    std::vector<ParticleIterator_t> OutParticleIterator(world.size());
     for (int rank = 0; rank < world.size(); rank++)
     {
       InParticleIterator[rank].init(InHalosSorted.begin() + SendHaloDisps[rank],
@@ -288,7 +287,7 @@ static void ExchangeHalos(MpiWorker_t &world, vector<Halo_t> &InHalos, vector<Ha
       OutParticleIterator[rank].init(NewHalos + RecvHaloDisps[rank],
                                      NewHalos + RecvHaloDisps[rank] + RecvHaloCounts[rank]);
     }
-    vector<HBTInt> InParticleCount(world.size(), 0);
+    std::vector<HBTInt> InParticleCount(world.size(), 0);
     for (HBTInt i = 0; i < InHalosSorted.size(); i++)
       InParticleCount[TargetRank[i].Rank] += InHalosSorted[i].Particles.size();
 
@@ -299,9 +298,9 @@ static void ExchangeHalos(MpiWorker_t &world, vector<Halo_t> &InHalos, vector<Ha
   }
 }
 
-void ExchangeAndMerge(MpiWorker_t &world, vector<Halo_t> &Halos)
+void ExchangeAndMerge(MpiWorker_t &world, std::vector<Halo_t> &Halos)
 {
-  vector<Halo_t> LocalHalos;
+  std::vector<Halo_t> LocalHalos;
   MPI_Datatype MPI_Halo_Shell_t;
   create_MPI_Halo_Id_type(MPI_Halo_Shell_t);
   ExchangeHalos(world, Halos, LocalHalos, MPI_Halo_Shell_t);

--- a/src/io/comms/exchange_and_merge.h
+++ b/src/io/comms/exchange_and_merge.h
@@ -1,4 +1,3 @@
-using namespace std;
 #include <assert.h>
 #include <chrono>
 #include <cstdio>
@@ -12,4 +11,4 @@ using namespace std;
 
 #include "../../mymath.h"
 
-void ExchangeAndMerge(MpiWorker_t &world, vector<Halo_t> &Halos);
+void ExchangeAndMerge(MpiWorker_t &world, std::vector<Halo_t> &Halos);

--- a/src/io/gadget_io/gadget4_io.cpp
+++ b/src/io/gadget_io/gadget4_io.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <iostream>
 #include <numeric>
 #include <sstream>
@@ -100,10 +99,10 @@ void Gadget4Reader_t::SetSnapshot(int snapshotId)
   SnapshotId = snapshotId;
   if (HBTConfig.SnapshotNameList.empty())
   {
-    stringstream formatter;
+    std::stringstream formatter;
     if (HBTConfig.SnapshotDirBase.length() > 0)
-      formatter << HBTConfig.SnapshotDirBase << "_" << setw(3) << setfill('0') << snapshotId << "/";
-    formatter << HBTConfig.SnapshotFileBase << "_" << setw(3) << setfill('0') << snapshotId;
+      formatter << HBTConfig.SnapshotDirBase << "_" << std::setw(3) << std::setfill('0') << snapshotId << "/";
+    formatter << HBTConfig.SnapshotFileBase << "_" << std::setw(3) << std::setfill('0') << snapshotId;
     SnapshotName = formatter.str();
   }
   else
@@ -134,7 +133,7 @@ std::string Gadget4Reader_t::GetGroupFileName(int ifile)
   if (HBTConfig.SnapshotDirBase.length() > 0)
   {
     /* If only FoF was run. */
-    formatter << HBTConfig.HaloPath << "groups_" << setw(3) << setfill('0') << SnapshotId << "/fof_tab_" << snap_idname << "." << ifile << ".hdf5";
+    formatter << HBTConfig.HaloPath << "groups_" << std::setw(3) << std::setfill('0') << SnapshotId << "/fof_tab_" << snap_idname << "." << ifile << ".hdf5";
     bool is_valid_file = is_it_valid(formatter.str());
 
     if(is_valid_file)
@@ -143,7 +142,7 @@ std::string Gadget4Reader_t::GetGroupFileName(int ifile)
     std::stringstream().swap(formatter); // Empty stringstream
 
     /* Subfind or Subfind-HBT was also run. */
-    formatter << HBTConfig.HaloPath << "groups_" << setw(3) << setfill('0') << SnapshotId << "/fof_subhalo_tab_" << snap_idname << "." << ifile << ".hdf5";
+    formatter << HBTConfig.HaloPath << "groups_" << std::setw(3) << std::setfill('0') << SnapshotId << "/fof_subhalo_tab_" << snap_idname << "." << ifile << ".hdf5";
   }
   else
   {
@@ -205,11 +204,11 @@ Gadget4Header_t Gadget4Reader_t::ReadHeader(int ifile)
   int DM_softening_class;
   ReadAttribute(file, "Parameters", "SofteningClassOfPartType1", H5T_NATIVE_INT, &DM_softening_class);
 
-  stringstream DM_comoving_softening_dataset;
+  std::stringstream DM_comoving_softening_dataset;
   DM_comoving_softening_dataset << "SofteningComovingClass" << DM_softening_class;
   ReadAttribute(file, "Parameters", DM_comoving_softening_dataset.str().c_str(), H5T_NATIVE_DOUBLE, &HeaderThisFile.DM_comoving_softening);
 
-  stringstream DM_max_softening_dataset;
+  std::stringstream DM_max_softening_dataset;
   DM_max_softening_dataset << "SofteningComovingClass" << DM_softening_class;
   ReadAttribute(file, "Parameters", DM_max_softening_dataset.str().c_str(), H5T_NATIVE_DOUBLE, &HeaderThisFile.DM_maximum_physical_softening);
 
@@ -290,8 +289,8 @@ void Gadget4Reader_t::CompileSnapshotParticleOffsets(int NumberFiles)
   }
 }
 
-HBTInt Gadget4Reader_t::CompileGroupFileOffsets(vector<HBTInt> &nhalo_per_groupfile,
-                                                vector<HBTInt> &offsethalo_per_groupfile)
+HBTInt Gadget4Reader_t::CompileGroupFileOffsets(std::vector<HBTInt> &nhalo_per_groupfile,
+                                                std::vector<HBTInt> &offsethalo_per_groupfile)
 {
   HBTInt offset = 0, nhalo_total;
   int nfiles = nhalo_per_groupfile.size();
@@ -353,7 +352,7 @@ void Gadget4Reader_t::ReadSnapshot(int FirstFileIndex, int CurrentFileIndex, Par
                                  + OffsetPreviousParticleTypes \
                                  + OffsetParticlesPerTypePerFile[CurrentFileIndex][PartType] - OffsetParticlesPerTypePerFile[FirstFileIndex][PartType];
 
-    stringstream grpname;
+    std::stringstream grpname;
     grpname << "PartType" << PartType;
 
     if (!H5Lexists(file, grpname.str().c_str(), H5P_DEFAULT))
@@ -384,7 +383,7 @@ void Gadget4Reader_t::ReadSnapshot(int FirstFileIndex, int CurrentFileIndex, Par
       HBTReal aexp;
       ReadAttribute(particle_data, "Velocities", "a_scaling", H5T_HBTReal, &aexp);
 
-      vector<HBTxyz> v(NumberParticlesThisTypeToRead);
+      std::vector<HBTxyz> v(NumberParticlesThisTypeToRead);
       ReadDataset(particle_data, "Velocities", H5T_HBTReal, v.data());
 
 #pragma omp parallel for
@@ -395,7 +394,7 @@ void Gadget4Reader_t::ReadSnapshot(int FirstFileIndex, int CurrentFileIndex, Par
 
     /* Particle IDs */
     {
-      vector<HBTInt> id(NumberParticlesThisTypeToRead);
+      std::vector<HBTInt> id(NumberParticlesThisTypeToRead);
       ReadDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data());
 #pragma omp parallel for
       for (int i = 0; i < NumberParticlesThisTypeToRead; i++)
@@ -405,7 +404,7 @@ void Gadget4Reader_t::ReadSnapshot(int FirstFileIndex, int CurrentFileIndex, Par
     /* Particle masses */
     if (Header.mass[PartType] == 0)
     {
-      vector<HBTReal> m(NumberParticlesThisTypeToRead);
+      std::vector<HBTReal> m(NumberParticlesThisTypeToRead);
       ReadDataset(particle_data, "Masses", H5T_HBTReal, m.data());
 #pragma omp parallel for
       for (int i = 0; i < NumberParticlesThisTypeToRead; i++)
@@ -423,7 +422,7 @@ void Gadget4Reader_t::ReadSnapshot(int FirstFileIndex, int CurrentFileIndex, Par
 #ifdef HAS_THERMAL_ENERGY
     if (PartType == 0)
     {
-      vector<HBTReal> u(NumberParticlesThisTypeToRead);
+      std::vector<HBTReal> u(NumberParticlesThisTypeToRead);
       ReadDataset(particle_data, "InternalEnergy", H5T_HBTReal, u.data());
 #pragma omp parallel for
       for (int i = 0; i < NumberParticlesThisTypeToRead; i++)
@@ -489,7 +488,7 @@ void Gadget4Reader_t::ReadGroupLenPerType(int ifile, std::array<HBTInt, TypeMax>
   H5Fclose(file);
 }
 
-void Gadget4Reader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles,
+void Gadget4Reader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, std::vector<Particle_t> &Particles,
                                    Cosmology_t &Cosmology)
 {
   SetSnapshot(snapshotId);
@@ -809,11 +808,11 @@ struct HaloPartitioner_t
       local_halo_sizes.resize(nhalos);
 
       if (nhalos > 0)
-        local_halo_sizes[0] = min(HaloOffsets[first_halo + 1], ProcOffsets[iproc + 1]) - ProcOffsets[iproc];
+        local_halo_sizes[0] = std::min(HaloOffsets[first_halo + 1], ProcOffsets[iproc + 1]) - ProcOffsets[iproc];
       for (HBTInt i = 1; i < nhalos - 1; i++)
         local_halo_sizes[i] = HaloSizes[i + first_halo];
       if (nhalos > 1)
-        local_halo_sizes.back() = min(HaloSizes[last_halo], ProcOffsets[iproc + 1] - HaloOffsets[last_halo]);
+        local_halo_sizes.back() = std::min(HaloSizes[last_halo], ProcOffsets[iproc + 1] - HaloOffsets[last_halo]);
     }
   }
 
@@ -1092,7 +1091,7 @@ void Gadget4Reader_t::LoadGroups(MpiWorker_t &world, const ParticleSnapshot_t &p
   HBTConfig.GroupLoadedFullParticle = true;
 }
 
-bool IsGadget4Group(const string &GroupFileFormat)
+bool IsGadget4Group(const std::string &GroupFileFormat)
 {
   return GroupFileFormat.substr(0, 7) == "gadget4";
 }

--- a/src/io/gadget_io/gadget4_io.h
+++ b/src/io/gadget_io/gadget4_io.h
@@ -87,7 +87,7 @@ class Gadget4Reader_t
   void ReadGroupLen(int ifile, HBTInt *buf);
   void ReadGroupLenPerType(int ifile, std::array<HBTInt, TypeMax> *buf);
   HBTInt ReadGroupFileTotParticles(int ifile);
-  void LoadParticleHosts(MpiWorker_t &world, vector<Particle_t> &Particles);
+  void LoadParticleHosts(MpiWorker_t &world, std::vector<Particle_t> &Particles);
   void CreateHaloSegments(const std::vector<Particle_t> &SnapshotParticles, std::vector<Halo_t> &Halos);
 
   /* Custom MPI datatypes for easier communication. */

--- a/src/io/gadget_io/gadget_group_io.cpp
+++ b/src/io/gadget_io/gadget_group_io.cpp
@@ -35,7 +35,7 @@ bool GetGroupFileByteOrder(const char *filename, const int FileCounts)
   int Nfiles, n, ns;
   long offset;
   FILE *fp;
-  string GroupFileFormat = HBTConfig.GroupFileFormat;
+  std::string GroupFileFormat = HBTConfig.GroupFileFormat;
 
   if (GroupFileFormat == "gadget4")
     n = sizeof(GroupV4Header_t);
@@ -63,12 +63,12 @@ bool GetGroupFileByteOrder(const char *filename, const int FileCounts)
   if (Nfiles == ns)
     return true;
 
-  cerr << "endianness check failed for: " << filename << ", file format not expected:" << Nfiles << ';' << n << ';'
-       << ns << endl;
+  std::cerr << "endianness check failed for: " << filename << ", file format not expected:" << Nfiles << ';' << n << ';'
+       << ns << std::endl;
   exit(1);
 }
 
-void GetFileNameFormat(int SnapshotId, string &format, int &FileCounts, bool &IsSubFile, bool &NeedByteSwap)
+void GetFileNameFormat(int SnapshotId, std::string &format, int &FileCounts, bool &IsSubFile, bool &NeedByteSwap)
 {
   IsSubFile = false;
   FileCounts = 1;
@@ -133,15 +133,14 @@ void GetFileNameFormat(int SnapshotId, string &format, int &FileCounts, bool &Is
     return;
   }
 
-  // 	return 0;
-  cerr << "Error: no group files found under " << HBTConfig.HaloPath << " at snapshot " << SnapshotId << endl;
+  std::cerr << "Error: no group files found under " << HBTConfig.HaloPath << " at snapshot " << SnapshotId << std::endl;
   exit(1);
 }
 
 class GroupFileReader_t
 {
 private:
-  string filename_format;
+  std::string filename_format;
   bool IsSubFile, NeedByteSwap;
   int iFile;
   int SnapshotId;
@@ -152,8 +151,8 @@ private:
 public:
   HBTInt NumberOfGroups;    // in file, not necessarily the same as read
   HBTInt NumberOfParticles; // in file, not necessarily the same as read
-  vector<HBTInt> Particles;
-  vector<int> Len, Offset;
+  std::vector<HBTInt> Particles;
+  std::vector<int> Len, Offset;
   int FileCounts;
 
   GroupFileReader_t(int SnapshotId)
@@ -203,7 +202,7 @@ void GroupFileReader_t::ReadV2V3(int read_level, HBTInt start_particle, HBTInt e
   }
   if (FileCounts != NFiles)
   {
-    cout << "File count mismatch for file " << filename << ": expect " << FileCounts << ", got " << NFiles << endl;
+    std::cout << "File count mismatch for file " << filename << ": expect " << FileCounts << ", got " << NFiles << std::endl;
     exit(1);
   }
   if (read_level == READ_META_DATA)
@@ -248,7 +247,7 @@ void GroupFileReader_t::ReadV2V3(int read_level, HBTInt start_particle, HBTInt e
   if (end_particle < 0)
     end_particle = Nids;
   HBTInt Nread = end_particle - start_particle;
-  vector<PIDtype_t> PIDs(Nread);
+  std::vector<PIDtype_t> PIDs(Nread);
   fseek(fd, sizeof(PIDtype_t) * start_particle, SEEK_CUR);
   myfread(PIDs.data(), sizeof(PIDtype_t), Nread, fd);
   PIDtype_t Mask = HBTConfig.GroupParticleIdMask;
@@ -259,8 +258,8 @@ void GroupFileReader_t::ReadV2V3(int read_level, HBTInt start_particle, HBTInt e
   fseek(fd, sizeof(PIDtype_t) * (Nids - end_particle), SEEK_CUR);
   if (long int extra_bytes = BytesToEOF(fd))
   {
-    cerr << "Error: unexpected format of " << filename << endl;
-    cerr << extra_bytes << " extra bytes beyond particleId block! Check if particleId has a different type?\n";
+    std::cerr << "Error: unexpected format of " << filename << std::endl;
+    std::cerr << extra_bytes << " extra bytes beyond particleId block! Check if particleId has a different type?\n";
     exit(1);
   }
   if (feof(fd))
@@ -277,13 +276,13 @@ void GroupFileReader_t::Read(int ifile, int read_level, HBTInt start_particle, H
 {
   iFile = ifile;
 
-  string GroupFileFormat = HBTConfig.GroupFileFormat;
+  std::string GroupFileFormat = HBTConfig.GroupFileFormat;
   if (GroupFileFormat == "gadget2_int" || GroupFileFormat == "gadget3_int")
     ReadV2V3<int>(read_level, start_particle, end_particle);
   else if (GroupFileFormat == "gadget2_long" || GroupFileFormat == "gadget3_long")
     ReadV2V3<long>(read_level, start_particle, end_particle);
   else
-    throw(runtime_error("unknown GroupFileFormat " + GroupFileFormat));
+    throw(std::runtime_error("Unknown GroupFileFormat " + GroupFileFormat));
 }
 
 struct FileAssignment_t
@@ -340,8 +339,8 @@ struct FileAssignment_t
   }
 };
 
-typedef vector<HBTInt> ParticleIdBuffer_t;
-typedef vector<HBTInt> CountBuffer_t;
+typedef std::vector<HBTInt> ParticleIdBuffer_t;
+typedef std::vector<HBTInt> CountBuffer_t;
 void AssignHaloTasks(int nworkers, HBTInt npart_tot, const CountBuffer_t &HaloOffsets, const CountBuffer_t &FileOffsets,
                      HBTInt &npart_begin, FileAssignment_t &task)
 {
@@ -366,14 +365,15 @@ void AssignHaloTasks(int nworkers, HBTInt npart_tot, const CountBuffer_t &HaloOf
 
   npart_begin = npart_end;
 }
-void Load(MpiWorker_t &world, int SnapshotId, vector<Halo_t> &Halos)
+
+void Load(MpiWorker_t &world, int SnapshotId, std::vector<Halo_t> &Halos)
 {
   GroupFileReader_t Reader(SnapshotId);
   int FileCounts = Reader.FileCounts;
   CountBuffer_t HaloLenBuffer;
 
   /* Determine which tasks will read which haloes. */
-  vector<FileAssignment_t> alltasks;
+  std::vector<FileAssignment_t> alltasks;
   FileAssignment_t thistask;
   if (world.rank() == 0)
   {
@@ -468,7 +468,7 @@ void Load(MpiWorker_t &world, int SnapshotId, vector<Halo_t> &Halos)
   global_timer.Tick("halo_io", world.Communicator);
 }
 
-bool IsGadgetGroup(const string &GroupFileFormat)
+bool IsGadgetGroup(const std::string &GroupFileFormat)
 {
   return GroupFileFormat.substr(0, 6) == "gadget";
 }
@@ -497,8 +497,8 @@ int main(int argc, char **argv)
   if (halo.Halos.size() > 1)
   {
     auto &h = halo.Halos[1];
-    cout << " Halo 1 from thread " << world.rank() << ":"
-         << "id=" << h.HaloId << "," << h.Particles.size() << ", " << h.Particles[5] << endl;
+    std::cout << " Halo 1 from thread " << world.rank() << ":"
+         << "id=" << h.HaloId << "," << h.Particles.size() << ", " << h.Particles[5] << std::endl;
   }
 
   MPI_Finalize();

--- a/src/io/gadget_io/gadget_group_io.h
+++ b/src/io/gadget_io/gadget_group_io.h
@@ -24,8 +24,8 @@ struct GroupV4Header_t
   int flag_doubleprecision; // long? no, but padding may exist
 };
 
-extern void Load(MpiWorker_t &world, int SnapshotId, vector<Halo_t> &Halos);
-extern bool IsGadgetGroup(const string &GroupFileFormat);
+extern void Load(MpiWorker_t &world, int SnapshotId, std::vector<Halo_t> &Halos);
+extern bool IsGadgetGroup(const std::string &GroupFileFormat);
 
 } // namespace GadgetGroup
 

--- a/src/io/gadget_io/gadget_io.cpp
+++ b/src/io/gadget_io/gadget_io.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <iostream>
 #include <numeric>
 #include <assert.h>
@@ -57,7 +56,7 @@ void GadgetHeader_t::create_MPI_type(MPI_Datatype &dtype)
 #undef NumAttr
 }
 
-GadgetReader_t::GadgetReader_t(MpiWorker_t &world, int snapshot_id, vector<Particle_t> &particles,
+GadgetReader_t::GadgetReader_t(MpiWorker_t &world, int snapshot_id, std::vector<Particle_t> &particles,
                                Cosmology_t &cosmology)
   : SnapshotId(snapshot_id), Particles(particles), Cosmology(cosmology), Header()
 {
@@ -72,7 +71,7 @@ GadgetReader_t::GadgetReader_t(MpiWorker_t &world, int snapshot_id, vector<Parti
 #define SkipVelocityBlock(fp) SkipFortranBlock(fp, NeedByteSwap)
 #define SkipIdBlock(fp) SkipFortranBlock(fp, NeedByteSwap)
 #define ReadBlockSize(a) myfread(&a, sizeof(a), 1, fp)
-void GadgetReader_t::GetGadgetFileName(int ifile, string &filename)
+void GadgetReader_t::GetGadgetFileName(int ifile, std::string &filename)
 {
   FILE *fp;
   char buf[1024];
@@ -91,7 +90,7 @@ void GadgetReader_t::GetGadgetFileName(int ifile, string &filename)
             ifile); // for BJL's RAMSES output
   if (!file_exist(buf))
   {
-    cerr << "Failed to find a snapshot file at " << buf << endl;
+    std::cerr << "Failed to find a snapshot file at " << buf << std::endl;
     exit(1);
   }
   filename = buf;
@@ -111,9 +110,9 @@ bool GadgetReader_t::ReadGadgetFileHeader(FILE *fp, GadgetHeader_t &header)
     NeedByteSwap = true;
   else
   {
-    cerr << "endianness check failed for header\n file format not expected:" << dummy << " not match headersize "
-         << headersize << " or " << headersize_byteswap << endl
-         << flush;
+    std::cerr << "endianness check failed for header\n file format not expected:" << dummy << " not match headersize "
+         << headersize << " or " << headersize_byteswap << std::endl
+         << std::flush;
     exit(1);
   }
   dummy = headersize;
@@ -151,7 +150,7 @@ bool GadgetReader_t::ReadGadgetFileHeader(FILE *fp, GadgetHeader_t &header)
 HBTInt GadgetReader_t::ReadGadgetNumberOfParticles(int ifile)
 {
   FILE *fp;
-  string filename;
+  std::string filename;
   GetGadgetFileName(ifile, filename);
   myfopen(fp, filename.c_str(), "r");
   GadgetHeader_t header;
@@ -172,7 +171,7 @@ void GadgetReader_t::LoadGadgetHeader(int ifile)
   // read the header part, assign header extensions, and check byteorder
 
   FILE *fp;
-  string filename;
+  std::string filename;
   GetGadgetFileName(ifile, filename);
 
   myfopen(fp, filename.c_str(), "r");
@@ -180,8 +179,8 @@ void GadgetReader_t::LoadGadgetHeader(int ifile)
 
   if ((HBTReal)Header.BoxSize != HBTConfig.BoxSize)
   {
-    cerr << "BoxSize not match input: read " << Header.BoxSize << "; expect " << HBTConfig.BoxSize << endl;
-    cerr << "Maybe the length unit differ? Expected unit: " << HBTConfig.LengthInMpch << " Mpc/h\n";
+    std::cerr << "BoxSize not match input: read " << Header.BoxSize << "; expect " << HBTConfig.BoxSize << std::endl;
+    std::cerr << "Maybe the length unit differ? Expected unit: " << HBTConfig.LengthInMpch << " Mpc/h\n";
     exit(1);
   }
 
@@ -195,7 +194,7 @@ void GadgetReader_t::LoadGadgetHeader(int ifile)
   blocksize = SkipVelocityBlock(fp);
   assert(blocksize == RealTypeSize * NumPartInFile * 3);
   if (sizeof(HBTReal) < RealTypeSize)
-    cerr << "WARNING: loading size " << RealTypeSize << " float in snapshot with size " << sizeof(HBTReal)
+    std::cerr << "WARNING: loading size " << RealTypeSize << " float in snapshot with size " << sizeof(HBTReal)
          << " float in HBT. possible loss of accuracy.\n Please use ./HBTdouble unless you know what you are doing.";
 
   if (HBTConfig.SnapshotHasIdBlock)
@@ -204,9 +203,6 @@ void GadgetReader_t::LoadGadgetHeader(int ifile)
     IntTypeSize = blocksize / NumPartInFile;
     assert(sizeof(int) == IntTypeSize || sizeof(long) == IntTypeSize);
     assert(sizeof(HBTInt) >= IntTypeSize);
-    // 	if(sizeof(HBTInt)<IntTypeSize)
-    // 	  cerr<<"WARNING: loading size "<<IntTypeSize<<" integer in snapshot with size "<<sizeof(HBTInt)<<" int in HBT.
-    // possible data overflow.\n Please use ./HBTdouble unless you know what you are doing.";
   }
 
   fclose(fp);
@@ -260,8 +256,6 @@ void GadgetReader_t::Load(MpiWorker_t &world)
         ReadGadgetFile(iFile);
     }
   }
-
-  //   cout<<" ( "<<Header.num_files<<" total files ) : "<<Particles.size()<<" particles loaded."<<endl;
 }
 
 #define ReadScalarBlock(dtype, Attr)                                                                                   \
@@ -285,7 +279,7 @@ void GadgetReader_t::Load(MpiWorker_t &world)
 #define ReadMassBlock(dtype)                                                                                           \
   {                                                                                                                    \
     size_t n_read_mass = 0;                                                                                            \
-    vector<HBTInt> offset_mass(TypeMax);                                                                               \
+    std::vector<HBTInt> offset_mass(TypeMax);                                                                               \
     for (int itype = 0; itype < TypeMax; itype++)                                                                      \
       if (MassDataPresent(itype))                                                                                      \
       {                                                                                                                \
@@ -342,7 +336,7 @@ void GadgetReader_t::Load(MpiWorker_t &world)
 void GadgetReader_t::ReadGadgetFile(int iFile)
 {
   FILE *fp;
-  string filename;
+  std::string filename;
   GetGadgetFileName(iFile, filename);
   myfopen(fp, filename.c_str(), "r");
   GadgetHeader_t header;
@@ -350,10 +344,10 @@ void GadgetReader_t::ReadGadgetFile(int iFile)
 #ifdef DM_ONLY
   size_t n_read = header.npart[TypeDM], n_skip = accumulate(header.npart, header.npart + TypeDM, size_t(0));
 #else
-  size_t n_read = accumulate(begin(header.npart), end(header.npart), (size_t)0), n_skip = 0;
+  size_t n_read = std::accumulate(std::begin(header.npart), std::end(header.npart), (size_t)0), n_skip = 0;
 #endif
-  vector<HBTInt> offset(TypeMax);
-  CompileOffsets(begin(header.npart), end(header.npart), offset.begin());
+  std::vector<HBTInt> offset(TypeMax);
+  CompileOffsets(std::begin(header.npart), std::end(header.npart), offset.begin());
 
   Particles.resize(Particles.size() + n_read);
   const auto NewParticles = Particles.end() - n_read;
@@ -438,7 +432,7 @@ void GadgetReader_t::ReadGadgetFile(int iFile)
 
   if (feof(fp))
   {
-    cout << "Error: End-of-File when reading " << filename << endl;
+    std::cout << "Error: End-of-File when reading " << filename << std::endl;
     exit(1);
   }
 

--- a/src/io/gadget_io/gadget_io.cpp
+++ b/src/io/gadget_io/gadget_io.cpp
@@ -342,7 +342,7 @@ void GadgetReader_t::ReadGadgetFile(int iFile)
   GadgetHeader_t header;
   ReadGadgetFileHeader(fp, header);
 #ifdef DM_ONLY
-  size_t n_read = header.npart[TypeDM], n_skip = accumulate(header.npart, header.npart + TypeDM, size_t(0));
+  size_t n_read = header.npart[TypeDM], n_skip = std::accumulate(header.npart, header.npart + TypeDM, size_t(0));
 #else
   size_t n_read = std::accumulate(std::begin(header.npart), std::end(header.npart), (size_t)0), n_skip = 0;
 #endif

--- a/src/io/gadget_io/gadget_io.h
+++ b/src/io/gadget_io/gadget_io.h
@@ -26,7 +26,7 @@ struct GadgetHeader_t
 
 class GadgetReader_t
 {
-  vector<Particle_t> &Particles;
+  std::vector<Particle_t> &Particles;
   Cosmology_t &Cosmology;
 
   int SnapshotId;
@@ -34,17 +34,17 @@ class GadgetReader_t
   bool NeedByteSwap;
   int IntTypeSize;
   int RealTypeSize;
-  vector<HBTInt> NumberOfParticleInFiles;
-  vector<HBTInt> OffsetOfParticleInFiles;
+  std::vector<HBTInt> NumberOfParticleInFiles;
+  std::vector<HBTInt> OffsetOfParticleInFiles;
   void ReadGadgetFile(int ifile);
   void LoadGadgetHeader(int ifile = 0);
   bool ReadGadgetFileHeader(FILE *fp, GadgetHeader_t &header);
   HBTInt ReadGadgetNumberOfParticles(int ifile);
-  void GetGadgetFileName(int ifile, string &filename);
+  void GetGadgetFileName(int ifile, std::string &filename);
   void Load(MpiWorker_t &world);
 
 public:
-  GadgetReader_t(MpiWorker_t &world, int snapshot_id, vector<Particle_t> &particles, Cosmology_t &cosmology);
+  GadgetReader_t(MpiWorker_t &world, int snapshot_id, std::vector<Particle_t> &particles, Cosmology_t &cosmology);
 };
 
 #endif

--- a/src/io/halo_io.cpp
+++ b/src/io/halo_io.cpp
@@ -23,7 +23,7 @@ void HaloSnapshot_t::Load(MpiWorker_t &world, const ParticleSnapshot_t &partsnap
   int snapshot_index = partsnap.GetSnapshotIndex();
   SetSnapshotIndex(snapshot_index);
 
-  string GroupFileFormat = HBTConfig.GroupFileFormat;
+  std::string GroupFileFormat = HBTConfig.GroupFileFormat;
 
   if (GadgetGroup::IsGadgetGroup(GroupFileFormat))
   {
@@ -43,7 +43,7 @@ void HaloSnapshot_t::Load(MpiWorker_t &world, const ParticleSnapshot_t &partsnap
      * MyGroupReader(world, SnapshotId, Halos) */
   }
   else
-    throw(runtime_error("unknown GroupFileFormat " + GroupFileFormat));
+    throw(std::runtime_error("Unknown GroupFileFormat " + GroupFileFormat));
 
   NumPartOfLargestHalo = 0;
   TotNumberOfParticles = 0;
@@ -85,8 +85,8 @@ int main(int argc, char **argv)
   if (halo.Halos.size() > 1)
   {
     auto &h = halo.Halos[1];
-    cout << " Halo 1 from thread " << world.rank() << ":"
-         << "id=" << h.HaloId << "," << h.Particles.size() << ", " << h.Particles[5] << endl;
+    std::cout << " Halo 1 from thread " << world.rank() << ":"
+         << "id=" << h.HaloId << "," << h.Particles.size() << ", " << h.Particles[5] << std::endl;
   }
 
   MPI_Finalize();

--- a/src/io/snapshot_io.cpp
+++ b/src/io/snapshot_io.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include <iostream>
-// #include <iomanip>
 #include <assert.h>
 #include <chrono>
 #include <cstdio>
@@ -54,7 +52,7 @@ void ParticleSnapshot_t::Load(MpiWorker_t &world, int snapshot_index)
      * LoadMySnapshot(SnapshotId, Particles, Cosmology); */
   }
   else
-    throw(runtime_error("unknown SnapshotFormat " + HBTConfig.SnapshotFormat));
+    throw(std::runtime_error("unknown SnapshotFormat " + HBTConfig.SnapshotFormat));
 
   global_timer.Tick("snap_io", world.Communicator);
 
@@ -77,11 +75,11 @@ int main(int argc, char **argv)
   HBTConfig.ParseConfigFile(argv[1]);
   ParticleSnapshot_t snapshot;
   snapshot.Load(HBTConfig.MaxSnapshotIndex, true);
-  cout << snapshot.GetNumberOfParticles() << endl;
-  cout << snapshot.GetParticleId(10) << endl;
-  cout << snapshot.GetComovingPosition(10) << endl;
-  cout << snapshot.GetParticleMass(10) << ',' << snapshot.GetParticleMass(100) << endl;
-  cout << snapshot.GetParticleIndex(snapshot.GetParticleId(10)) << endl;
+  std::cout << snapshot.GetNumberOfParticles() << std::endl;
+  std::cout << snapshot.GetParticleId(10) << std::endl;
+  std::cout << snapshot.GetComovingPosition(10) << std::endl;
+  std::cout << snapshot.GetParticleMass(10) << ',' << snapshot.GetParticleMass(100) << std::endl;
+  std::cout << snapshot.GetParticleIndex(snapshot.GetParticleId(10)) << std::endl;
   return 0;
 }
 #endif

--- a/src/io/subhalo_io.cpp
+++ b/src/io/subhalo_io.cpp
@@ -98,17 +98,17 @@ void SubhaloSnapshot_t::BuildHDFDataType()
   H5Tclose(H5T_HBTxyz);
 }
 
-string SubhaloSnapshot_t::GetSubDir()
+std::string SubhaloSnapshot_t::GetSubDir()
 {
-  stringstream formater;
-  formater << HBTConfig.SubhaloPath << "/" << setw(3) << setfill('0') << SnapshotId;
+  std::stringstream formater;
+  formater << HBTConfig.SubhaloPath << "/" << std::setw(3) << std::setfill('0') << SnapshotId;
   return formater.str();
 }
 
-void SubhaloSnapshot_t::GetSubFileName(string &filename, int iFile, const string &ftype)
+void SubhaloSnapshot_t::GetSubFileName(std::string &filename, int iFile, const std::string &ftype)
 {
-  stringstream formater;
-  formater << GetSubDir() << "/" + ftype + "Snap_" << setw(3) << setfill('0') << SnapshotId << "." << iFile
+  std::stringstream formater;
+  formater << GetSubDir() << "/" + ftype + "Snap_" << std::setw(3) << std::setfill('0') << SnapshotId << "." << iFile
            << ".hdf5"; // or use snapshotid
   filename = formater.str();
 }
@@ -118,7 +118,7 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
   if (snapshot_index < HBTConfig.MinSnapshotIndex)
   {
     if (world.rank() == 0)
-      cout << "Skipping empty snapshot " << snapshot_index << "\n";
+      std::cout << "Skipping empty snapshot " << snapshot_index << "\n";
     return;
   }
   SetSnapshotIndex(snapshot_index);
@@ -127,7 +127,7 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
   HBTInt TotNumberOfSubs;
   if (world.rank() == 0)
   {
-    string filename;
+    std::string filename;
     GetSubFileName(filename, 0);
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
@@ -160,10 +160,10 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
   {
     if (NumSubsAll_loaded != TotNumberOfSubs)
     {
-      ostringstream msg;
+      std::ostringstream msg;
       msg << "Error reading SubSnap " << snapshot_index << ": total number of subhaloes expected=" << TotNumberOfSubs
-          << ", loaded=" << NumSubsAll_loaded << endl;
-      throw runtime_error(msg.str().c_str());
+          << ", loaded=" << NumSubsAll_loaded << std::endl;
+      throw std::runtime_error(msg.str().c_str());
     }
     std::cout << TotNumberOfSubs << " subhalos loaded from snapshot " << SnapshotId << " (SnapshotIndex = " \
               << snapshot_index << ")" << std::endl;
@@ -188,7 +188,7 @@ void SubhaloSnapshot_t::Load(MpiWorker_t &world, int snapshot_index, const SubRe
 void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
 { // Read iFile for current snapshot.
 
-  string filename;
+  std::string filename;
   GetSubFileName(filename, iFile);
   hid_t dset, file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   HBTInt snapshot_id;
@@ -216,7 +216,7 @@ void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
   if (nsubhalos)
   {
     Subhalo_t *NewSubhalos = &Subhalos[nsubhalos_old];
-    vector<hvl_t> vl(dims[0]);
+    std::vector<hvl_t> vl(dims[0]);
     vl.resize(nsubhalos);
     hid_t H5T_HBTIntArr = H5Tvlen_create(H5T_HBTInt);
     if (depth == SubReaderDepth_t::SubParticles || depth == SubReaderDepth_t::SrcParticles)
@@ -271,7 +271,7 @@ void SubhaloSnapshot_t::ReadFile(int iFile, const SubReaderDepth_t depth)
 void SubhaloSnapshot_t::Save(MpiWorker_t &world)
 {
   /* Create folder where to save files */
-  string subdir = GetSubDir();
+  std::string subdir = GetSubDir();
   mkdir(subdir.c_str(), 0755);
 
   /* Decide how many ranks per node write simultaneously */
@@ -335,7 +335,7 @@ void SubhaloSnapshot_t::WriteSourceFiles(MpiWorker_t &world, const int &number_r
 void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsAll)
 {
   /* Create file */
-  string filename;
+  std::string filename;
   GetSubFileName(filename, iFile);
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -368,7 +368,7 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
   writeStringAttribute(header, commit_hash, "Git_commit");
   H5Gclose(header);
 
-  vector<hvl_t> vl(Subhalos.size());
+  std::vector<hvl_t> vl(Subhalos.size());
   hsize_t dim_sub[] = {Subhalos.size()};
   // now write the particle list for each subhalo
   if (HBTConfig.SaveBoundParticleProperties)
@@ -452,7 +452,7 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
     H5Tclose(H5T_FloatArr);
   }
 
-  vector<HBTInt> IdBuffer;
+  std::vector<HBTInt> IdBuffer;
   {
     HBTInt NumberOfParticles = 0;
     for (HBTInt i = 0; i < Subhalos.size(); i++)
@@ -478,7 +478,7 @@ void SubhaloSnapshot_t::WriteBoundSubfile(int iFile, int nfiles, HBTInt NumSubsA
 void SubhaloSnapshot_t::WriteSourceSubfile(int iFile, int nfiles)
 {
   /* Create file */
-  string filename;
+  std::string filename;
   GetSubFileName(filename, iFile, "Src");
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -496,8 +496,8 @@ void SubhaloSnapshot_t::WriteSourceSubfile(int iFile, int nfiles)
 
   /* Create the particle vector arrays here, which is different to vl in the
    * WriteBoundSubfile, due to cleaning Particle vectors  */
-  vector<hvl_t> vl(Subhalos.size());
-  vector<HBTInt> IdBuffer;
+  std::vector<hvl_t> vl(Subhalos.size());
+  std::vector<HBTInt> IdBuffer;
   {
     HBTInt NumberOfParticles = 0;
     for (HBTInt i = 0; i < Subhalos.size(); i++)

--- a/src/io/swiftsim_io/swiftsim_io.cpp
+++ b/src/io/swiftsim_io/swiftsim_io.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <iostream>
 #include <numeric>
 #include <cassert>
@@ -71,19 +70,19 @@ void SwiftSimReader_t::SetSnapshot(int snapshotId)
 {
   if (HBTConfig.SnapshotNameList.empty())
   {
-    stringstream formatter;
+    std::stringstream formatter;
     if (HBTConfig.SnapshotDirBase.length() > 0)
-      formatter << HBTConfig.SnapshotDirBase << "_" << setw(4) << setfill('0') << snapshotId << "/";
-    formatter << HBTConfig.SnapshotFileBase << "_" << setw(4) << setfill('0') << snapshotId;
+      formatter << HBTConfig.SnapshotDirBase << "_" << std::setw(4) << std::setfill('0') << snapshotId << "/";
+    formatter << HBTConfig.SnapshotFileBase << "_" << std::setw(4) << std::setfill('0') << snapshotId;
     SnapshotName = formatter.str();
   }
   else
     SnapshotName = HBTConfig.SnapshotNameList[snapshotId];
 }
 
-void SwiftSimReader_t::GetFileName(int ifile, string &filename)
+void SwiftSimReader_t::GetFileName(int ifile, std::string &filename)
 {
-  stringstream formatter;
+  std::stringstream formatter;
   if (ifile < 0)
     formatter << HBTConfig.SnapshotPath << "/" << SnapshotName << ".hdf5";
   else
@@ -93,7 +92,7 @@ void SwiftSimReader_t::GetFileName(int ifile, string &filename)
 
 hid_t SwiftSimReader_t::OpenFile(int ifile)
 {
-  string filename;
+  std::string filename;
 
   H5E_auto_t err_func;
   char *err_data;
@@ -114,7 +113,7 @@ hid_t SwiftSimReader_t::OpenFile(int ifile)
 
   if (file < 0)
   {
-    cout << "Failed to open file: " << filename << "\n";
+    std::cout << "Failed to open file: " << filename << "\n";
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
 
@@ -134,7 +133,7 @@ void SwiftSimReader_t::ReadHeader(int ifile, SwiftSimHeader_t &header)
   ReadAttribute(file, "Header", "BoxSize", H5T_NATIVE_DOUBLE, BoxSize_3D);
   if (BoxSize_3D[0] != BoxSize_3D[1] || BoxSize_3D[0] != BoxSize_3D[2])
   {
-    cout << "Swift simulation box must have equal size in each dimension!\n";
+    std::cout << "Swift simulation box must have equal size in each dimension!\n";
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
   Header.BoxSize = BoxSize_3D[0]; // Can only handle cubic boxes
@@ -162,7 +161,7 @@ void SwiftSimReader_t::ReadHeader(int ifile, SwiftSimHeader_t &header)
   ReadAttribute(file, "Units", "Unit time in cgs (U_t)", H5T_NATIVE_DOUBLE, &time_cgs);
 
   /* Read group ID used to indicate that a particle is in no FoF group */
-  string buf;
+  std::string buf;
   ReadAttribute(file, "Parameters", "FOF:group_id_default", buf);
   // Check if using HBTInt would not overflow value
   long long NullGroupId = std::stoll(buf);
@@ -247,7 +246,7 @@ HBTInt SwiftSimReader_t::CompileFileOffsets(int nfiles)
     hid_t file = OpenFile(ifile);
     GetParticleCountInFile(file, np_this);
     H5Fclose(file);
-    HBTInt np = accumulate(begin(np_this), end(np_this), (HBTInt)0);
+    HBTInt np = std::accumulate(std::begin(np_this), std::end(np_this), (HBTInt)0);
 
     np_file.push_back(np);
     offset += np;
@@ -268,8 +267,8 @@ static void check_id_size(hid_t loc)
 void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTInt file_start, HBTInt file_count)
 {
   hid_t file = OpenFile(ifile);
-  vector<HBTInt> np_this(TypeMax);
-  vector<HBTInt> offset_this(TypeMax);
+  std::vector<HBTInt> np_this(TypeMax);
+  std::vector<HBTInt> offset_this(TypeMax);
   GetParticleCountInFile(file, np_this.data());
   CompileOffsets(np_this, offset_this);
 
@@ -303,7 +302,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
     assert(read_offset + read_count <= np_this[itype]);
 
     // Open the HDF5 group for this type
-    stringstream grpname;
+    std::stringstream grpname;
     grpname << "PartType" << itype;
     hid_t particle_data = H5Gopen2(file, grpname.str().c_str(), H5P_DEFAULT);
     check_id_size(particle_data);
@@ -317,7 +316,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
       ReadAttribute(particle_data, "Coordinates", "a-scale exponent", H5T_HBTReal, &aexp);
       if (aexp != 1.0)
       {
-        cout << "Can't handle Coordinates with a-scale exponent != 1\n";
+        std::cout << "Can't handle Coordinates with a-scale exponent != 1\n";
         MPI_Abort(MPI_COMM_WORLD, 1);
       }
 
@@ -328,7 +327,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         hsize_t count = read_count - offset; // number left to read
         if (count > chunksize)
           count = chunksize;
-        vector<HBTxyz> x(count);
+        std::vector<HBTxyz> x(count);
         ReadPartialDataset(particle_data, "Coordinates", H5T_HBTReal, x.data(), offset + read_offset, count);
         // Box wrap if necessary
         if (HBTConfig.PeriodicBoundaryOn)
@@ -356,7 +355,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         hsize_t count = read_count - offset;
         if (count > chunksize)
           count = chunksize;
-        vector<HBTxyz> v(count);
+        std::vector<HBTxyz> v(count);
         ReadPartialDataset(particle_data, "Velocities", H5T_HBTReal, v.data(), offset + read_offset, count);
         // Convert units and store the particle velocities
         for (hsize_t i = 0; i < count; i += 1)
@@ -372,7 +371,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         hsize_t count = read_count - offset;
         if (count > chunksize)
           count = chunksize;
-        vector<HBTInt> id(count);
+        std::vector<HBTInt> id(count);
         ReadPartialDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].Id = id[i];
@@ -393,7 +392,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         hsize_t count = read_count - offset;
         if (count > chunksize)
           count = chunksize;
-        vector<HBTReal> m(count);
+        std::vector<HBTReal> m(count);
         ReadPartialDataset(particle_data, name.c_str(), H5T_HBTReal, m.data(), offset + read_offset, count);
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].Mass = m[i] * pow(Header.ScaleFactor, aexp);
@@ -412,7 +411,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         hsize_t count = read_count - offset;
         if (count > chunksize)
           count = chunksize;
-        vector<HBTReal> u(count);
+        std::vector<HBTReal> u(count);
         ReadPartialDataset(particle_data, "InternalEnergies", H5T_HBTReal, u.data(), offset + read_offset, count);
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].InternalEnergy = u[i] * pow(Header.ScaleFactor, aexp);
@@ -439,7 +438,7 @@ void SwiftSimReader_t::ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTI
         hsize_t count = read_count - offset;
         if (count > chunksize)
           count = chunksize;
-        vector<HBTInt> id(count);
+        std::vector<HBTInt> id(count);
         ReadPartialDataset(particle_data, "FOFGroupIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].HostId = id[i];
@@ -457,8 +456,8 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
                                           bool FlagReadParticleId)
 {
   hid_t file = OpenFile(ifile);
-  vector<HBTInt> np_this(TypeMax);
-  vector<HBTInt> offset_this(TypeMax);
+  std::vector<HBTInt> np_this(TypeMax);
+  std::vector<HBTInt> offset_this(TypeMax);
   GetParticleCountInFile(file, np_this.data());
   CompileOffsets(np_this, offset_this);
 
@@ -491,7 +490,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
     assert(read_offset + read_count <= np_this[itype]);
 
     // Open the HDF5 group for this particle type
-    stringstream grpname;
+    std::stringstream grpname;
     grpname << "PartType" << itype;
     hid_t particle_data = H5Gopen2(file, grpname.str().c_str(), H5P_DEFAULT);
 
@@ -507,7 +506,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
         ReadAttribute(particle_data, "Coordinates", "a-scale exponent", H5T_HBTReal, &aexp);
         if (aexp != 1.0)
         {
-          cout << "Can't handle Coordinates with a-scale exponent != 1\n";
+          std::cout << "Can't handle Coordinates with a-scale exponent != 1\n";
           MPI_Abort(MPI_COMM_WORLD, 1);
         }
 
@@ -518,7 +517,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           hsize_t count = read_count - offset;
           if (count > chunksize)
             count = chunksize;
-          vector<HBTxyz> x(count);
+          std::vector<HBTxyz> x(count);
           ReadPartialDataset(particle_data, "Coordinates", H5T_HBTReal, x.data(), offset + read_offset, count);
           // Box wrap if necessary
           if (HBTConfig.PeriodicBoundaryOn)
@@ -546,7 +545,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           hsize_t count = read_count - offset;
           if (count > chunksize)
             count = chunksize;
-          vector<HBTxyz> v(count);
+          std::vector<HBTxyz> v(count);
           ReadPartialDataset(particle_data, "Velocities", H5T_HBTReal, v.data(), offset + read_offset, count);
           // Convert units and store the particle velocities
           for (hsize_t i = 0; i < count; i += 1)
@@ -562,7 +561,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           hsize_t count = read_count - offset;
           if (count > chunksize)
             count = chunksize;
-          vector<HBTInt> id(count);
+          std::vector<HBTInt> id(count);
           ReadPartialDataset(particle_data, "ParticleIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
           for (hsize_t i = 0; i < count; i += 1)
             ParticlesToRead[offset + i].Id = id[i];
@@ -583,7 +582,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           hsize_t count = read_count - offset;
           if (count > chunksize)
             count = chunksize;
-          vector<HBTReal> m(count);
+          std::vector<HBTReal> m(count);
           ReadPartialDataset(particle_data, name.c_str(), H5T_HBTReal, m.data(), offset + read_offset, count);
           for (hsize_t i = 0; i < count; i += 1)
             ParticlesToRead[offset + i].Mass = m[i] * pow(Header.ScaleFactor, aexp);
@@ -602,7 +601,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
           hsize_t count = read_count - offset;
           if (count > chunksize)
             count = chunksize;
-          vector<HBTReal> u(count);
+          std::vector<HBTReal> u(count);
           ReadPartialDataset(particle_data, "InternalEnergies", H5T_HBTReal, u.data(), offset + read_offset, count);
           for (hsize_t i = 0; i < count; i += 1)
             ParticlesToRead[offset + i].InternalEnergy = u[i] * pow(Header.ScaleFactor, aexp);
@@ -630,7 +629,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
         hsize_t count = read_count - offset;
         if (count > chunksize)
           count = chunksize;
-        vector<HBTInt> id(count);
+        std::vector<HBTInt> id(count);
         ReadPartialDataset(particle_data, "FOFGroupIDs", H5T_HBTInt, id.data(), offset + read_offset, count);
         for (hsize_t i = 0; i < count; i += 1)
           ParticlesToRead[offset + i].HostId = id[i];
@@ -643,7 +642,7 @@ void SwiftSimReader_t::ReadGroupParticles(int ifile, Particle_t *ParticlesInFile
   H5Fclose(file);
 }
 
-void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles,
+void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, std::vector<Particle_t> &Particles,
                                     Cosmology_t &Cosmology)
 {
 
@@ -769,14 +768,13 @@ void SwiftSimReader_t::LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<P
   // Every rank should have executed the reading code exactly once
   assert(reads_done == 1);
 
-  // #define SNAPSHOT_IO_TEST
 #ifdef SNAPSHOT_IO_TEST
   // For testing: dump the snapshot to a new set of files
   // Generate test file name for this MPI  rank
-  stringstream formatter1;
-  formatter1 << HBTConfig.SubhaloPath << "/" << setw(3) << setfill('0') << snapshotId << "/"
-             << "test_" << setw(3) << setfill('0') << snapshotId << "." << world.rank() << ".hdf5";
-  string tfilename = formatter1.str();
+  std::stringstream formatter1;
+  formatter1 << HBTConfig.SubhaloPath << "/" << std::setw(3) << std::setfill('0') << snapshotId << "/"
+             << "test_" << std::setw(3) << std::setfill('0') << snapshotId << "." << world.rank() << ".hdf5";
+  std::string tfilename = formatter1.str();
   // Create array of coordinates
   double *pos = (double *)malloc(3 * sizeof(double) * np_local);
   for (size_t i = 0; i < np_local; i += 1)
@@ -822,7 +820,7 @@ inline bool CompParticleHost(const Particle_t &a, const Particle_t &b)
   return a.HostId < b.HostId;
 }
 
-void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo_t> &Halos)
+void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, std::vector<Halo_t> &Halos)
 { // read in particle properties at the same time, to avoid particle look-up at later stage.
   SetSnapshot(snapshotId);
 
@@ -862,7 +860,7 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
   assert(local_last_offset < np_total);
 
   // Allocate storage for the particles
-  vector<Particle_t> ParticleHosts;
+  std::vector<Particle_t> ParticleHosts;
   ParticleHosts.resize(np_local);
 
   bool FlagReadId = true; //! HBTConfig.GroupLoadedIndex;
@@ -922,10 +920,10 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
   // For testing: dump the snapshot to a new set of files
   //
   // Generate test file name for this MPI  rank
-  stringstream formatter1;
-  formatter1 << HBTConfig.SubhaloPath << "/" << setw(3) << setfill('0') << snapshotId << "/"
-             << "test_halo_" << setw(3) << setfill('0') << snapshotId << "." << world.rank() << ".hdf5";
-  string tfilename = formatter1.str();
+  std::stringstream formatter1;
+  formatter1 << HBTConfig.SubhaloPath << "/" << std::setw(3) << std::setfill('0') << snapshotId << "/"
+             << "test_halo_" << std::setw(3) << std::setfill('0') << snapshotId << "." << world.rank() << ".hdf5";
+  std::string tfilename = formatter1.str();
   // Create array of coordinates
   double *pos = (double *)malloc(3 * sizeof(double) * np_local);
   for (size_t i = 0; i < np_local; i += 1)
@@ -990,7 +988,7 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
     {
     }
   };
-  vector<HaloLen_t> HaloLen;
+  std::vector<HaloLen_t> HaloLen;
 
   HBTInt curr_host_id = Header.NullGroupId;
   for (auto &&p : ParticleHosts)
@@ -1028,17 +1026,17 @@ void SwiftSimReader_t::LoadGroups(MpiWorker_t &world, int snapshotId, vector<Hal
   HBTConfig.GroupLoadedFullParticle = true;
 }
 
-bool IsSwiftSimGroup(const string &GroupFileFormat)
+bool IsSwiftSimGroup(const std::string &GroupFileFormat)
 {
   return GroupFileFormat.substr(0, 8) == "swiftsim";
 }
 
 /* Returns the path to the file containing information about which
  * particles have split between the current and previous output. */
-void SwiftSimReader_t::GetParticleSplitFileName(int snapshotId, string &filename)
+void SwiftSimReader_t::GetParticleSplitFileName(int snapshotId, std::string &filename)
 {
-  stringstream formatter;
-  formatter << HBTConfig.SubhaloPath << "/ParticleSplits/particle_splits_" << setw(4) << setfill('0') << snapshotId
+  std::stringstream formatter;
+  formatter << HBTConfig.SubhaloPath << "/ParticleSplits/particle_splits_" << std::setw(4) << std::setfill('0') << snapshotId
             << ".hdf5";
   filename = formatter.str();
 }
@@ -1052,13 +1050,13 @@ hid_t SwiftSimReader_t::OpenParticleSplitFile(int snapshotId)
   H5Eset_auto(H5E_DEFAULT, NULL, NULL);
 
   /* Open file with split information, which is contained in a single HDF5 file. */
-  string filename;
+  std::string filename;
   GetParticleSplitFileName(snapshotId, filename);
   hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
 
   if (file < 0)
   {
-    cout << "Failed to open file (see toolbox/swiftsim on how to generate): " << filename << "\n";
+    std::cout << "Failed to open file (see toolbox/swiftsim on how to generate): " << filename << "\n";
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
 
@@ -1081,15 +1079,15 @@ void SwiftSimReader_t::ReadParticleSplits(std::unordered_map<HBTInt, HBTInt> &Pa
     return;
 
   /* Open the HDF5 group */
-  stringstream grpname;
+  std::stringstream grpname;
   grpname << "SplitInformation";
   hid_t split_data = H5Gopen2(file, grpname.str().c_str(), H5P_DEFAULT);
 
   /* Load keys and values */
-  vector<HBTInt> SplitKeys(NumberSplits);
+  std::vector<HBTInt> SplitKeys(NumberSplits);
   ReadDataset(split_data, "Keys", H5T_HBTInt, SplitKeys.data());
 
-  vector<HBTInt> SplitValues(NumberSplits);
+  std::vector<HBTInt> SplitValues(NumberSplits);
   ReadDataset(split_data, "Values", H5T_HBTInt, SplitValues.data());
 
   /* Populate the map */

--- a/src/io/swiftsim_io/swiftsim_io.h
+++ b/src/io/swiftsim_io/swiftsim_io.h
@@ -42,9 +42,9 @@ void create_SwiftSimHeader_MPI_type(MPI_Datatype &dtype);
 
 class SwiftSimReader_t
 {
-  string SnapshotName;
-  vector<HBTInt> np_file;
-  vector<HBTInt> offset_file;
+  std::string SnapshotName;
+  std::vector<HBTInt> np_file;
+  std::vector<HBTInt> offset_file;
   SwiftSimHeader_t Header;
   hid_t OpenFile(int ifile);
   void ReadHeader(int ifile, SwiftSimHeader_t &header);
@@ -53,12 +53,12 @@ class SwiftSimReader_t
   void ReadSnapshot(int ifile, Particle_t *ParticlesInFile, HBTInt file_start, HBTInt file_count);
   void ReadGroupParticles(int ifile, Particle_t *ParticlesInFile, HBTInt file_start, HBTInt file_count,
                           bool FlagReadParticleId);
-  void GetFileName(int ifile, string &filename);
+  void GetFileName(int ifile, std::string &filename);
   void SetSnapshot(int snapshotId);
   void GetParticleCountInFile(hid_t file, HBTInt np[]);
 
   /* To load information about particle splits */
-  void GetParticleSplitFileName(int snapshotId, string &filename);
+  void GetParticleSplitFileName(int snapshotId, std::string &filename);
   hid_t OpenParticleSplitFile(int snapshotId);
 
   MPI_Datatype MPI_SwiftSimHeader_t;
@@ -72,10 +72,10 @@ public:
   {
     MPI_Type_free(&MPI_SwiftSimHeader_t);
   }
-  void LoadSnapshot(MpiWorker_t &world, int snapshotId, vector<Particle_t> &Particles, Cosmology_t &Cosmology);
-  void LoadGroups(MpiWorker_t &world, int snapshotId, vector<Halo_t> &Halos);
+  void LoadSnapshot(MpiWorker_t &world, int snapshotId, std::vector<Particle_t> &Particles, Cosmology_t &Cosmology);
+  void LoadGroups(MpiWorker_t &world, int snapshotId, std::vector<Halo_t> &Halos);
   void ReadParticleSplits(std::unordered_map<HBTInt, HBTInt> &ParticleSplitMap, int snapshotId);
 };
 
-extern bool IsSwiftSimGroup(const string &GroupFileFormat);
+extern bool IsSwiftSimGroup(const std::string &GroupFileFormat);
 #endif

--- a/src/linkedlist.cpp
+++ b/src/linkedlist.cpp
@@ -97,29 +97,11 @@ void Linkedlist_t::merge()
     }
   }
 
-  // equivalent way:
-  //   #pragma omp parallel for
-  //   for(int ichain=0;ichain<HOC.size();ichain++)
-  //   {
-  //     auto *p=&HOC[ichain];
-  //     for(int ithread=0;ithread<LLs.size();ithread++)
-  //     {
-  //       auto pid=LLs[ithread].HOC[ichain];
-  //       while(pid>=0)//copy till tail
-  //       {
-  // 	*p=Samples[ithread].restore_id(pid);//copy
-  // 	pid=LLs[ithread].List[pid];//next value
-  // 	p=&List[*p];//next storage
-  //       }
-  //     }
-  //     *p=-1;//close the chain
-  //   }
-
   LLs.clear();
   Samples.clear();
 }
 
-void LinkedlistLinkGroup(HBTReal radius, const Snapshot_t &snapshot, vector<HBTInt> &GrpLen, vector<HBTInt> &GrpTags,
+void LinkedlistLinkGroup(HBTReal radius, const Snapshot_t &snapshot, std::vector<HBTInt> &GrpLen, std::vector<HBTInt> &GrpTags,
                          int ndiv)
 /* link particles in the given snapshot into groups.
  * Output: filled GrpLen and GrpTags (0~Ngroups-1), down to mass=1 (diffuse particles)
@@ -127,22 +109,22 @@ void LinkedlistLinkGroup(HBTReal radius, const Snapshot_t &snapshot, vector<HBTI
 {
   GrpTags.assign(snapshot.size(), -1);
 
-  cout << "Building linkedlist...\n" << flush;
+  std::cout << "Building linkedlist...\n" << std::flush;
 
   SnapshotPos_t posdata(snapshot);
   Linkedlist_t ll(ndiv, &posdata, HBTConfig.BoxSize, HBTConfig.PeriodicBoundaryOn);
 
-  cout << "Linking Groups...\n" << flush;
+  std::cout << "Linking Groups...\n" << std::flush;
   HBTInt grpid = 0;
   HBTInt printstep = snapshot.size() / 100, progress = printstep;
-  cout << "00%" << flush;
+  std::cout << "00%" << std::flush;
   for (HBTInt i = 0; i < snapshot.size(); i++)
   {
     if (GrpTags[i] < 0)
     {
       if (i >= progress)
       {
-        cout << "\b\b\b" << setw(2) << progress / printstep << "%" << flush;
+        std::cout << "\b\b\b" << std::setw(2) << progress / printstep << "%" << std::flush;
         progress += printstep;
       }
       GrpTags[i] = grpid; // infect the seed particle
@@ -152,5 +134,5 @@ void LinkedlistLinkGroup(HBTReal radius, const Snapshot_t &snapshot, vector<HBTI
     }
   }
 
-  cout << "Found " << GrpLen.size() << " Groups\n";
+  std::cout << "Found " << GrpLen.size() << " Groups\n";
 }

--- a/src/linkedlist.h
+++ b/src/linkedlist.h
@@ -22,7 +22,7 @@ public:
   {
     return i;
   }
-  void restore_id(vector<LocatedParticle_t> &particles) const
+  void restore_id(std::vector<LocatedParticle_t> &particles) const
   {
     for (auto &&p : particles)
       p.index = restore_id(p.index);
@@ -68,8 +68,8 @@ class LinkedlistPara_t
 { // built and searched in parallel. can be searched in serial as well. lower efficiency than Linkedlist_t, especially
   // when built with larger number of threads.
 private:
-  vector<LinkedlistBase_t> LLs;
-  vector<PositionSampleLattice_t> Samples;
+  std::vector<LinkedlistBase_t> LLs;
+  std::vector<PositionSampleLattice_t> Samples;
 
 public:
   LinkedlistPara_t(int ndiv, PositionData_t *data, HBTReal boxsize = 0., bool periodic = false);
@@ -173,8 +173,8 @@ public:
 class Linkedlist_t : public LinkedlistBase_t
 { // built in parallel
 private:
-  vector<LinkedlistBase_t> LLs;
-  vector<PositionSampleBlock_t> Samples;
+  std::vector<LinkedlistBase_t> LLs;
+  std::vector<PositionSampleBlock_t> Samples;
   void merge();
 
 public:
@@ -193,6 +193,6 @@ public:
   void parallel_build(int ndiv, PositionData_t *data, HBTReal boxsize = 0., bool periodic = false);
 };
 
-extern void LinkedlistLinkGroup(HBTReal radius, const Snapshot_t &snapshot, vector<HBTInt> &GrpLen,
-                                vector<HBTInt> &GrpTags, int ndiv = 256);
+extern void LinkedlistLinkGroup(HBTReal radius, const Snapshot_t &snapshot, std::vector<HBTInt> &GrpLen,
+                                std::vector<HBTInt> &GrpTags, int ndiv = 256);
 #endif

--- a/src/linkedlist_base.cpp
+++ b/src/linkedlist_base.cpp
@@ -31,7 +31,6 @@ void LinkedlistBase_t::init(int ndiv, PositionData_t *data, HBTReal boxsize, boo
   BoxHalf = BoxSize / 2.;
 
   HBTInt i, j;
-  // cout<<"creating linked list for "<<particles.size()<<" particles..."<<endl;
   /*determining enclosing cube*/
   if (BoxSize)
   {
@@ -235,7 +234,7 @@ void LinkedlistBase_t::SearchCylinder(HBTReal radius_z, HBTReal radius_p, const 
       }
 }
 
-HBTInt LinkedlistBase_t::TagFriendsOfFriends(HBTInt seed, HBTInt grpid, vector<HBTInt> &group_tags, HBTReal LinkLength)
+HBTInt LinkedlistBase_t::TagFriendsOfFriends(HBTInt seed, HBTInt grpid, std::vector<HBTInt> &group_tags, HBTReal LinkLength)
 /*tag all the particles that are linked to seed with grpid
  * Note if system stack size is too small, this recursive routine may crash
  * in that case you should set:  ulimit -s unlimited  (bash) before running.
@@ -247,7 +246,7 @@ HBTInt LinkedlistBase_t::TagFriendsOfFriends(HBTInt seed, HBTInt grpid, vector<H
   HBTReal LinkLength2 = LinkLength * LinkLength;
   int i, j, k, subbox_grid[3][2];
 
-  vector<HBTInt> friends;
+  std::vector<HBTInt> friends;
 
   for (i = 0; i < 3; i++)
   {

--- a/src/linkedlist_base.h
+++ b/src/linkedlist_base.h
@@ -53,8 +53,8 @@ protected:
   void init(int ndiv, PositionData_t *data, HBTReal boxsize, bool periodic);
 
 public:
-  vector<HBTInt> HOC;
-  vector<HBTInt> List;
+  std::vector<HBTInt> HOC;
+  std::vector<HBTInt> List;
   LinkedlistBase_t() = default;
   LinkedlistBase_t(int ndiv, PositionData_t *data, HBTReal boxsize = 0., bool periodic = false)
   {
@@ -65,7 +65,7 @@ public:
   void SearchSphere(HBTReal radius, const HBTxyz &searchcenter, ParticleCollector_t &colletor);
   void SearchCylinder(HBTReal radius_z, HBTReal radius_p, const HBTxyz &searchcenter,
                       ParticleCollector_t &collector); // search within +-radius_z along z and projected radius_p
-  HBTInt TagFriendsOfFriends(HBTInt seed, HBTInt grpid, vector<HBTInt> &group_tags, HBTReal LinkLength);
+  HBTInt TagFriendsOfFriends(HBTInt seed, HBTInt grpid, std::vector<HBTInt> &group_tags, HBTReal LinkLength);
   HBTInt get_chain_length(int i)
   {
     HBTInt pid = HOC[i];
@@ -82,10 +82,10 @@ public:
     auto pid = HOC[i];
     while (pid >= 0)
     {
-      cout << pid << ",";
+      std::cout << pid << ",";
       pid = List[pid];
     }
-    cout << endl;
+    std::cout << std::endl;
   }
 };
 

--- a/src/mpi_wrapper.cpp
+++ b/src/mpi_wrapper.cpp
@@ -1,6 +1,5 @@
 #include "mpi_wrapper.h"
 #include <sstream>
-// using namespace std;
 
 void MpiWorker_t::SyncAtomBool(bool &x, int root)
 {
@@ -10,9 +9,9 @@ void MpiWorker_t::SyncAtomBool(bool &x, int root)
   MPI_Bcast(&y, 1, MPI_CHAR, root, Communicator);
   x = y;
 }
-void MpiWorker_t::SyncVectorBool(vector<bool> &x, int root)
+void MpiWorker_t::SyncVectorBool(std::vector<bool> &x, int root)
 {
-  vector<char> y;
+  std::vector<char> y;
   if (rank() == root)
     y.assign(x.begin(), x.end());
   SyncContainer(y, MPI_CHAR, root);
@@ -20,13 +19,13 @@ void MpiWorker_t::SyncVectorBool(vector<bool> &x, int root)
     x.assign(y.begin(), y.end());
 }
 
-void MpiWorker_t::SyncVectorString(vector<string> &x, int root)
+void MpiWorker_t::SyncVectorString(std::vector<std::string> &x, int root)
 {
-  string buffer;
+  std::string buffer;
 
   if (rank() == root)
   {
-    ostringstream file;
+    std::ostringstream file;
     for (auto &s : x)
       file << s << '\n';
     buffer = file.str();
@@ -37,8 +36,8 @@ void MpiWorker_t::SyncVectorString(vector<string> &x, int root)
   if (rank() != root)
   {
     x.clear();
-    istringstream file(buffer);
-    string s;
+    std::istringstream file(buffer);
+    std::string s;
     while (getline(file, s))
       x.push_back(s);
   }

--- a/src/mpi_wrapper.h
+++ b/src/mpi_wrapper.h
@@ -64,8 +64,8 @@ public:
   template <class T>
   void SyncAtom(T &x, MPI_Datatype dtype, int root_worker);
   void SyncAtomBool(bool &x, int root);
-  void SyncVectorBool(vector<bool> &x, int root);
-  void SyncVectorString(vector<string> &x, int root);
+  void SyncVectorBool(std::vector<bool> &x, int root);
+  void SyncVectorString(std::vector<std::string> &x, int root);
 };
 
 template <class T>
@@ -77,7 +77,7 @@ void MpiWorker_t::SyncContainer(T &x, MPI_Datatype dtype, int root_worker)
   {
     len = x.size();
     if (len >= INT_MAX)
-      throw runtime_error("Error: in SyncContainer(), sending more than INT_MAX elements with MPI causes overflow.\n");
+      throw std::runtime_error("Error: in SyncContainer(), sending more than INT_MAX elements with MPI causes overflow.\n");
   }
   MPI_Bcast(&len, 1, MPI_INT, root_worker, Communicator);
 
@@ -92,9 +92,9 @@ inline void MpiWorker_t::SyncAtom(T &x, MPI_Datatype dtype, int root_worker)
 }
 
 template <class T>
-void VectorAllToAll(MpiWorker_t &world, vector<vector<T>> &SendVecs, vector<vector<T>> &ReceiveVecs, MPI_Datatype dtype)
+void VectorAllToAll(MpiWorker_t &world, std::vector<std::vector<T>> &SendVecs, std::vector<std::vector<T>> &ReceiveVecs, MPI_Datatype dtype)
 {
-  vector<int> SendSizes(world.size()), ReceiveSizes(world.size());
+  std::vector<int> SendSizes(world.size()), ReceiveSizes(world.size());
   for (int i = 0; i < world.size(); i++)
     SendSizes[i] = SendVecs[i].size();
   MPI_Alltoall(SendSizes.data(), 1, MPI_INT, ReceiveSizes.data(), 1, MPI_INT, world.Communicator);
@@ -103,7 +103,7 @@ void VectorAllToAll(MpiWorker_t &world, vector<vector<T>> &SendVecs, vector<vect
   for (int i = 0; i < world.size(); i++)
     ReceiveVecs[i].resize(ReceiveSizes[i]);
 
-  vector<MPI_Datatype> SendTypes(world.size()), ReceiveTypes(world.size());
+  std::vector<MPI_Datatype> SendTypes(world.size()), ReceiveTypes(world.size());
   for (int i = 0; i < world.size(); i++)
   {
     MPI_Aint p;
@@ -115,7 +115,7 @@ void VectorAllToAll(MpiWorker_t &world, vector<vector<T>> &SendVecs, vector<vect
     MPI_Type_create_hindexed(1, &ReceiveSizes[i], &p, dtype, &ReceiveTypes[i]);
     MPI_Type_commit(&ReceiveTypes[i]);
   }
-  vector<int> Counts(world.size(), 1), Disps(world.size(), 0);
+  std::vector<int> Counts(world.size(), 1), Disps(world.size(), 0);
   MPI_Alltoallw(MPI_BOTTOM, Counts.data(), Disps.data(), SendTypes.data(), MPI_BOTTOM, Counts.data(), Disps.data(),
                 ReceiveTypes.data(), world.Communicator);
 
@@ -127,8 +127,8 @@ void VectorAllToAll(MpiWorker_t &world, vector<vector<T>> &SendVecs, vector<vect
 }
 
 template <class Particle_T, class InParticleIterator_T, class OutParticleIterator_T>
-void MyAllToAll(MpiWorker_t &world, vector<InParticleIterator_T> InParticleIterator,
-                const vector<HBTInt> &InParticleCount, vector<OutParticleIterator_T> OutParticleIterator,
+void MyAllToAll(MpiWorker_t &world, std::vector<InParticleIterator_T> InParticleIterator,
+                const std::vector<HBTInt> &InParticleCount, std::vector<OutParticleIterator_T> OutParticleIterator,
                 MPI_Datatype MPI_Particle_T, const HBTInt chunksize = 1024 * 1024)
 /*break the task into smaller pieces to avoid message size overflow
  * allocate a temporary buffer of type Particle_T to copy from InParticleIterator, send around, and copy out to
@@ -147,20 +147,20 @@ void MyAllToAll(MpiWorker_t &world, vector<InParticleIterator_T> InParticleItera
   if (0 == Nloop)
     return;
   // prepare loop size
-  vector<HBTInt> SendParticleCounts(world.size()), RecvParticleCounts(world.size()), SendParticleDisps(world.size()),
+  std::vector<HBTInt> SendParticleCounts(world.size()), RecvParticleCounts(world.size()), SendParticleDisps(world.size()),
     RecvParticleDisps(world.size());
-  vector<HBTInt> SendParticleRemainder(world.size());
+  std::vector<HBTInt> SendParticleRemainder(world.size());
   for (int rank = 0; rank < world.size(); rank++)
   {
     SendParticleCounts[rank] = InParticleCount[rank] / Nloop + 1; // distribute remainder to first few loops
     SendParticleRemainder[rank] = InParticleCount[rank] % Nloop;
   }
-  // 	cout<<"transmitting.."<<Nloop<<" loops: ";
+
   // transmit
-  vector<Particle_T> SendBuffer(chunksize + world.size()), RecvBuffer;
+  std::vector<Particle_T> SendBuffer(chunksize + world.size()), RecvBuffer;
   for (HBTInt iloop = 0; iloop < Nloop; iloop++)
   {
-    // 	  cout<<iloop<<" ";
+
     // header
     for (int rank = 0; rank < world.size(); rank++)
     {
@@ -198,7 +198,7 @@ void MyAllToAll(MpiWorker_t &world, vector<InParticleIterator_T> InParticleItera
       auto &it_part = OutParticleIterator[rank];
       for (auto it_buff = buff_begin; it_buff != buff_end; ++it_buff) // unpack
       {
-        *it_part = move(*it_buff);
+        *it_part = std::move(*it_buff);
         ++it_part;
       }
     }
@@ -221,7 +221,7 @@ void MyBcast(MpiWorker_t &world, InParticleIterator_T InParticleIterator, OutPar
     return;
   int buffersize = ParticleCount / Nloop + 1, nremainder = ParticleCount % Nloop;
   // transmit
-  vector<Particle_T> buffer(buffersize);
+  std::vector<Particle_T> buffer(buffersize);
   for (HBTInt iloop = 0; iloop < Nloop; iloop++)
   {
     if (iloop == nremainder) // switch sendcount from n+1 to n
@@ -233,14 +233,14 @@ void MyBcast(MpiWorker_t &world, InParticleIterator_T InParticleIterator, OutPar
     {
       for (auto it_buff = buffer.begin(); it_buff != buffer.end(); ++it_buff)
       {
-        *it_buff = move(*InParticleIterator);
+        *it_buff = std::move(*InParticleIterator);
         ++InParticleIterator;
       }
     }
     MPI_Bcast(buffer.data(), buffersize, MPI_Particle_T, root, world.Communicator);
     for (auto it_buff = buffer.begin(); it_buff != buffer.end(); ++it_buff) // unpack
     {
-      *OutParticleIterator = move(*it_buff);
+      *OutParticleIterator = std::move(*it_buff);
       ++OutParticleIterator;
     }
   }

--- a/src/mymath.cpp
+++ b/src/mymath.cpp
@@ -16,7 +16,7 @@ int GetGrid(HBTReal x, HBTReal step, int dim)
   return i;
 }
 
-int AssignCell(const HBTxyz &Pos, const HBTxyz &step, const vector<int> &dims)
+int AssignCell(const HBTxyz &Pos, const HBTxyz &step, const std::vector<int> &dims)
 {
 #define GRIDtoRank(g0, g1, g2) (((g0) * dims[1] + (g1)) * dims[2] + (g2))
 #define GID(i) GetGrid(Pos[i], step[i], dims[i])
@@ -88,9 +88,9 @@ int LargestRootFactor(int N, int dim)
 
 /* Return a factorization of `N` into `dim` factors that are as close as possible
  * to each other*/
-vector<int> ClosestFactors(int N, int dim)
+std::vector<int> ClosestFactors(int N, int dim)
 {
-  vector<int> factors;
+  std::vector<int> factors;
   for (; dim > 0; dim--)
   {
     int x = LargestRootFactor(N, dim);

--- a/src/mymath.h
+++ b/src/mymath.h
@@ -22,16 +22,16 @@
 #define VecNorm(x) VecDot(x, x)
 
 extern int GetGrid(HBTReal x, HBTReal step, int dim);
-extern int AssignCell(const HBTxyz &Pos, const HBTxyz &step, const vector<int> &dims);
+extern int AssignCell(const HBTxyz &Pos, const HBTxyz &step, const std::vector<int> &dims);
 
 template <class T>
-void VectorFree(vector<T> &x)
+void VectorFree(std::vector<T> &x)
 {
-  vector<T>().swap(x);
+  std::vector<T>().swap(x);
 }
 
 template <class T, class T2>
-size_t CompileOffsets(const vector<T> &Counts, vector<T2> &Offsets)
+size_t CompileOffsets(const std::vector<T> &Counts, std::vector<T2> &Offsets)
 {
   size_t offset = 0;
   Offsets.resize(Counts.size());
@@ -57,7 +57,7 @@ size_t CompileOffsets(CountIterator_t CountBegin, CountIterator_t CountEnd, Offs
 }
 
 template <class T, class UnaryPredicate>
-inline void RemoveFromVector(vector<T> &v, UnaryPredicate p)
+inline void RemoveFromVector(std::vector<T> &v, UnaryPredicate p)
 {
   v.erase(remove_if(v.begin(), v.end(), p), v.end());
 }
@@ -77,20 +77,20 @@ private:
     return itick < 0 ? itick + Size() : itick;
   }
 public:
-  vector<chrono::high_resolution_clock::time_point> tickers;
-  vector<string> names;
+  std::vector<std::chrono::high_resolution_clock::time_point> tickers;
+  std::vector<std::string> names;
   Timer_t() {tickers.reserve(20);}
 
   /* Every rank store the time without waiting for other ranks to finish. */
-  void Tick(string name)
+  void Tick(std::string name)
   {
-    tickers.push_back(chrono::high_resolution_clock::now());
+    tickers.push_back(std::chrono::high_resolution_clock::now());
     names.push_back(name);
   }
 
   /* We only store the time once all ranks reach the barrier, i.e. synchronised
    * ticking. */
-  void Tick(string name, MPI_Comm comm)
+  void Tick(std::string name, MPI_Comm comm)
   {
     MPI_Barrier(comm);
     Tick(name);
@@ -123,9 +123,9 @@ public:
     itick = FixTickNum(itick);
     itick0 = FixTickNum(itick0);
     if (itick < itick0)
-      swap(itick, itick0);
+      std::swap(itick, itick0);
 
-    return chrono::duration_cast<chrono::duration<double>>(tickers[itick] - tickers[itick0]).count();
+    return std::chrono::duration_cast<std::chrono::duration<double>>(tickers[itick] - tickers[itick0]).count();
   }
 
   double SaveSnapshotTiming(const std::string SubhaloPath, const int SnapshotIndex, const int SnapshotId)
@@ -162,31 +162,26 @@ extern Timer_t global_timer;
     fflush(stderr);                                                                                                    \
     exit(1);                                                                                                           \
   }
-// #ifdef PERIODIC_BDR
-// #define NEAREST(x) (((x)>BOXHALF)?((x)-BOXSIZE):(((x)<-BOXHALF)?((x)+BOXSIZE):(x)))
-/*this macro can well manipulate boundary condition because
- * usually a halo is much smaller than boxhalf
- * so that any distance within the halo should be smaller than boxhalf */
-// #endif
+
 #define get_bit(x, k) (((x) & (1 << k)) >> k)
 extern int count_pattern_files(char *filename_pattern);
-// extern std::ostream& operator << (std::ostream& o, HBTxyz &a);
 extern void swap_Nbyte(void *data2swap, size_t nel, size_t mbyte);
 extern size_t SkipFortranBlock(FILE *fp, bool NeedByteSwap);
+
 template <class T, std::size_t N>
-ostream &operator<<(ostream &o, const array<T, N> &arr)
+std::ostream &operator<<(std::ostream &o, const std::array<T, N> &arr)
 {
   o << "(";
-  copy(arr.cbegin(), arr.cend(), ostream_iterator<T>(o, ", "));
+  copy(arr.cbegin(), arr.cend(), std::ostream_iterator<T>(o, ", "));
   o << ")";
   return o;
 }
 
 template <class T>
-ostream &operator<<(ostream &o, const vector<T> &vec)
+std::ostream &operator<<(std::ostream &o, const std::vector<T> &vec)
 {
   o << "(";
-  copy(vec.cbegin(), vec.cend(), ostream_iterator<T>(o, ", "));
+  copy(vec.cbegin(), vec.cend(), std::ostream_iterator<T>(o, ", "));
   o << ")";
   return o;
 }
@@ -254,7 +249,7 @@ inline HBTReal Distance(const HBTReal x[3], const HBTxyz &y)
 template <class T>
 class FortranBlock
 {
-  vector<T> Data;
+  std::vector<T> Data;
   typedef T Txyz[3];
 
 public:
@@ -312,7 +307,7 @@ public:
   }
 };
 
-extern vector<int> ClosestFactors(int N, int dim);
+extern std::vector<int> ClosestFactors(int N, int dim);
 extern void AssignTasks(HBTInt worker_id, HBTInt nworkers, HBTInt ntasks, HBTInt &task_begin, HBTInt &task_end);
 
 #endif // of MYMATH_HEADER_INCLUDED

--- a/src/oct_tree.h
+++ b/src/oct_tree.h
@@ -7,13 +7,13 @@
 #include "snapshot.h"
 #include <exception>
 
-class OctTreeExceeded_t : public exception
+class OctTreeExceeded_t : public std::exception
 {
 private:
-  string msg;
+  std::string msg;
 
 public:
-  OctTreeExceeded_t(const string &message)
+  OctTreeExceeded_t(const std::string &message)
   {
     msg = message;
   }
@@ -50,10 +50,10 @@ class OctTree_t
 protected:
   typedef CellT OctTreeCell_t;
   /*the storage*/
-  vector<OctTreeCell_t> Cells;
+  std::vector<OctTreeCell_t> Cells;
   OctTreeCell_t *Nodes; /* =Cells-NumberOfParticles. the nodes are labelled from 0 to NumPart+NumNodes-1, so that
                            nodeid=0~NumPart-1 are particles, and nodeid>=NumPart are cells */
-  vector<HBTInt> NextnodeFromParticle; /* next node for each particle. Particles are the first NumPart nodes, and cells
+  std::vector<HBTInt> NextnodeFromParticle; /* next node for each particle. Particles are the first NumPart nodes, and cells
                                           are the remaining nodes.*/
   const Snapshot_t *Snapshot;
   HBTInt NumberOfParticles; // alias to Snapshot->GetSize().

--- a/src/oct_tree.tpp
+++ b/src/oct_tree.tpp
@@ -1,8 +1,3 @@
-// #include <cstdlib>
-// #include <cstdio>
-// #include <cmath>
-// #include <cstring>
-
 #include "mymath.h"
 #include "config_parser.h"
 

--- a/src/particle_exchanger.h
+++ b/src/particle_exchanger.h
@@ -78,7 +78,7 @@ void RestoreParticleOrder(OrderedParticleList_T &P)
     auto &p = P[i];
     auto &j = p.Order;
     while (i != j)
-      swap(p, P[j]);
+      std::swap(p, P[j]);
   }
 }
 } // namespace ParticleExchangeComp
@@ -93,17 +93,17 @@ class ParticleExchanger_t
   MPI_Datatype MPI_HBTParticle_t;
   MpiWorker_t &world;
   const ParticleSnapshot_t &snap;
-  vector<Halo_T> &InHalos;
+  std::vector<Halo_T> &InHalos;
 
-  vector<HBTInt> HaloSizes, HaloOffsets;
+  std::vector<HBTInt> HaloSizes, HaloOffsets;
 
-  vector<RemoteParticle_t> LocalParticles;
-  vector<OrderedParticle_t> RoamParticles;
-  typedef vector<RemoteParticle_t>::iterator LocalParticleIterator_t;
-  typedef vector<OrderedParticle_t>::iterator RoamParticleIterator_t;
-  vector<LocalParticleIterator_t> LocalIterators;
-  vector<RoamParticleIterator_t> RoamIterators;
-  vector<HBTInt> LocalSizes, RoamSizes;
+  std::vector<RemoteParticle_t> LocalParticles;
+  std::vector<OrderedParticle_t> RoamParticles;
+  typedef std::vector<RemoteParticle_t>::iterator LocalParticleIterator_t;
+  typedef std::vector<OrderedParticle_t>::iterator RoamParticleIterator_t;
+  std::vector<LocalParticleIterator_t> LocalIterators;
+  std::vector<RoamParticleIterator_t> RoamIterators;
+  std::vector<HBTInt> LocalSizes, RoamSizes;
 
   void CollectParticles();
   void SendParticles();
@@ -112,7 +112,7 @@ class ParticleExchanger_t
   void RestoreParticles();
 
 public:
-  ParticleExchanger_t(MpiWorker_t &world, const ParticleSnapshot_t &snap, vector<Halo_T> &InHalos);
+  ParticleExchanger_t(MpiWorker_t &world, const ParticleSnapshot_t &snap, std::vector<Halo_T> &InHalos);
   ~ParticleExchanger_t()
   {
     My_Type_free(&MPI_HBTParticle_t);
@@ -122,7 +122,7 @@ public:
 
 template <class Halo_T>
 ParticleExchanger_t<Halo_T>::ParticleExchanger_t(MpiWorker_t &world, const ParticleSnapshot_t &snap,
-                                                 vector<Halo_T> &InHalos)
+                                                 std::vector<Halo_T> &InHalos)
   : world(world), snap(snap), InHalos(InHalos), LocalParticles(), RoamParticles()
 {
   Particle_t().create_MPI_type(MPI_HBTParticle_t);
@@ -147,7 +147,7 @@ void ParticleExchanger_t<Halo_T>::CollectParticles()
   {
     for (auto &&p : h.Particles)
     {
-      LocalParticles.emplace_back(move(p), np++);
+      LocalParticles.emplace_back(std::move(p), np++);
     }
     h.Particles.clear(); // or hard clear to save memory?
   }
@@ -231,7 +231,7 @@ void ParticleExchanger_t<Halo_T>::RecvParticles()
 {
   MyAllToAll<Particle_t, RoamParticleIterator_t, LocalParticleIterator_t>(world, RoamIterators, RoamSizes,
                                                                           LocalIterators, MPI_HBTParticle_t);
-  vector<OrderedParticle_t>().swap(RoamParticles);
+  std::vector<OrderedParticle_t>().swap(RoamParticles);
 
   for (int rank = 0; rank < world.size(); rank++)
   {
@@ -254,7 +254,7 @@ void ParticleExchanger_t<Halo_T>::RestoreParticles()
     it = it_end;
   }
   assert(it == LocalParticles.end());
-  vector<RemoteParticle_t>().swap(LocalParticles);
+  std::vector<RemoteParticle_t>().swap(LocalParticles);
 
   for (auto &&h : InHalos)
     h.KickNullParticles();
@@ -271,7 +271,7 @@ void ParticleExchanger_t<Halo_T>::Exchange()
 }
 
 template <class Halo_T>
-void DecideTargetProcessor(int NumProc, vector<Halo_T> &InHalos, vector<IdRank_t> &TargetRank)
+void DecideTargetProcessor(int NumProc, std::vector<Halo_T> &InHalos, std::vector<IdRank_t> &TargetRank)
 {
   auto dims = ClosestFactors(NumProc, 3);
   HBTxyz step;
@@ -288,10 +288,10 @@ void DecideTargetProcessor(int NumProc, vector<Halo_T> &InHalos, vector<IdRank_t
 }
 
 template <class Halo_T>
-void ParticleSnapshot_t::ExchangeHalos(MpiWorker_t &world, vector<Halo_T> &InHalos, vector<Halo_T> &OutHalos,
+void ParticleSnapshot_t::ExchangeHalos(MpiWorker_t &world, std::vector<Halo_T> &InHalos, std::vector<Halo_T> &OutHalos,
                                        MPI_Datatype MPI_Halo_Shell_Type) const
 {
-  typedef typename vector<Halo_T>::iterator HaloIterator_t;
+  typedef typename std::vector<Halo_T>::iterator HaloIterator_t;
   typedef HaloParticleIterator_t<HaloIterator_t> ParticleIterator_t;
 
   //   cout<<"Query particle..."<<flush;
@@ -300,18 +300,18 @@ void ParticleSnapshot_t::ExchangeHalos(MpiWorker_t &world, vector<Halo_T> &InHal
     Exchanger.Exchange();
   }
 
-  vector<IdRank_t> TargetRank(InHalos.size());
+  std::vector<IdRank_t> TargetRank(InHalos.size());
   DecideTargetProcessor(world.size(), InHalos, TargetRank);
 
   // distribute halo shells
-  vector<int> SendHaloCounts(world.size(), 0), RecvHaloCounts(world.size()), SendHaloDisps(world.size()),
+  std::vector<int> SendHaloCounts(world.size(), 0), RecvHaloCounts(world.size()), SendHaloDisps(world.size()),
     RecvHaloDisps(world.size());
   sort(TargetRank.begin(), TargetRank.end(), CompareRank);
-  vector<Halo_T> InHalosSorted(InHalos.size());
-  vector<HBTInt> InHaloSizes(InHalos.size());
+  std::vector<Halo_T> InHalosSorted(InHalos.size());
+  std::vector<HBTInt> InHaloSizes(InHalos.size());
   for (HBTInt haloid = 0; haloid < InHalos.size(); haloid++)
   {
-    InHalosSorted[haloid] = move(InHalos[TargetRank[haloid].Id]);
+    InHalosSorted[haloid] = std::move(InHalos[TargetRank[haloid].Id]);
     SendHaloCounts[TargetRank[haloid].Rank]++;
     InHaloSizes[haloid] = InHalosSorted[haloid].Particles.size();
   }
@@ -323,7 +323,7 @@ void ParticleSnapshot_t::ExchangeHalos(MpiWorker_t &world, vector<Halo_T> &InHal
   MPI_Alltoallv(InHalosSorted.data(), SendHaloCounts.data(), SendHaloDisps.data(), MPI_Halo_Shell_Type, &NewHalos[0],
                 RecvHaloCounts.data(), RecvHaloDisps.data(), MPI_Halo_Shell_Type, world.Communicator);
   // resize receivehalos
-  vector<HBTInt> OutHaloSizes(NumNewHalos);
+  std::vector<HBTInt> OutHaloSizes(NumNewHalos);
   MPI_Alltoallv(InHaloSizes.data(), SendHaloCounts.data(), SendHaloDisps.data(), MPI_HBT_INT, OutHaloSizes.data(),
                 RecvHaloCounts.data(), RecvHaloDisps.data(), MPI_HBT_INT, world.Communicator);
   for (HBTInt i = 0; i < NumNewHalos; i++)
@@ -334,8 +334,8 @@ void ParticleSnapshot_t::ExchangeHalos(MpiWorker_t &world, vector<Halo_T> &InHal
     MPI_Datatype MPI_HBT_Particle;
     Particle_t().create_MPI_type(MPI_HBT_Particle);
     // create combined iterator for each bunch of haloes
-    vector<ParticleIterator_t> InParticleIterator(world.size());
-    vector<ParticleIterator_t> OutParticleIterator(world.size());
+    std::vector<ParticleIterator_t> InParticleIterator(world.size());
+    std::vector<ParticleIterator_t> OutParticleIterator(world.size());
     for (int rank = 0; rank < world.size(); rank++)
     {
       InParticleIterator[rank].init(InHalosSorted.begin() + SendHaloDisps[rank],
@@ -343,7 +343,7 @@ void ParticleSnapshot_t::ExchangeHalos(MpiWorker_t &world, vector<Halo_T> &InHal
       OutParticleIterator[rank].init(NewHalos + RecvHaloDisps[rank],
                                      NewHalos + RecvHaloDisps[rank] + RecvHaloCounts[rank]);
     }
-    vector<HBTInt> InParticleCount(world.size(), 0);
+    std::vector<HBTInt> InParticleCount(world.size(), 0);
     for (HBTInt i = 0; i < InHalosSorted.size(); i++)
       InParticleCount[TargetRank[i].Rank] += InHalosSorted[i].Particles.size();
 

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include <iostream>
-// #include <iomanip>
 #include <assert.h>
 #include <chrono>
 #include <cstdio>
@@ -13,30 +11,12 @@ using namespace std;
 #include "mymath.h"
 #include "snapshot.h"
 
-ostream &operator<<(ostream &o, Particle_t &p)
+std::ostream &operator<<(std::ostream &o, Particle_t &p)
 {
   o << "[" << p.Id << ", " << p.Mass << ", " << p.ComovingPosition << ", " << p.PhysicalVelocity << "]";
   return o;
 };
-/*
-void ParticleSnapshot_t::FillParticleHash()
-{
-  cout<<"Filling Hash Table...\n";
-  auto begin = chrono::high_resolution_clock::now();
-  ParticleHash.rehash(NumberOfParticles);
-  ParticleHash.reserve(NumberOfParticles);
-  for(HBTInt i=0;i<NumberOfParticles;i++)
-    ParticleHash[ParticleId[i]]=i;
-  auto end = chrono::high_resolution_clock::now();
-  auto elapsed = chrono::duration_cast<std::chrono::milliseconds>(end - begin);
-  cout << "inserts: " << elapsed.count() << endl;
-//   cout<<ParticleHash.bucket_count()<<" buckets used; load factor "<<ParticleHash.load_factor()<<endl;
-}
-void ParticleSnapshot_t::ClearParticleHash()
-{
-  ParticleHash.clear();
-}
-*/
+
 class ParticleKeyList_t : public KeyList_t<HBTInt, HBTInt>
 {
   typedef HBTInt Index_t;
@@ -253,7 +233,7 @@ double AverageVelocity(HBTxyz &CoV, const Particle_t Particles[], HBTInt NumPart
 }
 
 void Snapshot_t::SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor,
-                                          const vector<HBTReal> &RSorted, HBTReal ParticleMass) const
+                                          const std::vector<HBTReal> &RSorted, HBTReal ParticleMass) const
 /*
  * find SphericalOverdensitySize from a given list of sorted particle distances.
  * all distances comoving.
@@ -276,7 +256,7 @@ void Snapshot_t::SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal Viri
   Rvir = pow(i / RhoVirial, 1.0 / 3); // comoving
 }
 void Snapshot_t::SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor,
-                                          const vector<RadMassVel_t> &prof) const
+                                          const std::vector<RadMassVel_t> &prof) const
 /*
  * find SphericalOverdensitySize from a given list of sorted particle distances.
  * all distances comoving.
@@ -301,7 +281,7 @@ void Snapshot_t::SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal Viri
   }
 }
 void Snapshot_t::SphericalOverdensitySize2(float &Mvir, float &Rvir, HBTReal VirialFactor,
-                                           const vector<HBTReal> &RSorted, HBTReal ParticleMass) const
+                                           const std::vector<HBTReal> &RSorted, HBTReal ParticleMass) const
 /*
  * find SphericalOverdensitySize from a given list of sorted particle distances.
  * all distances comoving.
@@ -357,7 +337,7 @@ void ParticleSnapshot_t::ClearParticles()
 {
 #define RESET(x, T)                                                                                                    \
   {                                                                                                                    \
-    vector<T>().swap(x);                                                                                               \
+    std::vector<T>().swap(x);                                                                                               \
   }
   RESET(Particles, Particle_t);
 #undef RESET
@@ -368,6 +348,5 @@ void ParticleSnapshot_t::Clear()
 {
   ClearParticles();
   ClearParticleHash(); // even if you don't do this, the destructor will still clean up the memory.
-  //   cout<<NumberOfParticles<<" particles cleared from snapshot "<<SnapshotIndex<<endl;
   NumberOfParticlesOnAllNodes = 0;
 }

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -104,7 +104,7 @@ struct Particle_t
 #endif
   }
 };
-extern ostream &operator<<(ostream &o, Particle_t &p);
+extern std::ostream &operator<<(std::ostream &o, Particle_t &p);
 
 class Snapshot_t : public SnapshotNumber_t
 {
@@ -123,10 +123,10 @@ public:
   {
     return 0.;
   }
-  void SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor, const vector<HBTReal> &RSorted,
+  void SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor, const std::vector<HBTReal> &RSorted,
                                 HBTReal ParticleMass) const;
-  void SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor, const vector<RadMassVel_t> &prof) const;
-  void SphericalOverdensitySize2(float &Mvir, float &Rvir, HBTReal VirialFactor, const vector<HBTReal> &RSorted,
+  void SphericalOverdensitySize(float &Mvir, float &Rvir, HBTReal VirialFactor, const std::vector<RadMassVel_t> &prof) const;
+  void SphericalOverdensitySize2(float &Mvir, float &Rvir, HBTReal VirialFactor, const std::vector<HBTReal> &RSorted,
                                  HBTReal ParticleMass) const;
   void RelativeVelocity(const HBTxyz &targetPos, const HBTxyz &targetVel, const HBTxyz &refPos, const HBTxyz &refVel,
                         HBTxyz &relativeVel) const;
@@ -153,7 +153,7 @@ public:
   HBTInt *Ids;
   HBTInt N;
   Snapshot_t &Snapshot;
-  SnapshotView_t(vector<HBTInt> &ids, Snapshot_t &fullsnapshot)
+  SnapshotView_t(std::vector<HBTInt> &ids, Snapshot_t &fullsnapshot)
     : Ids(ids.data()), N(ids.size()), Snapshot(fullsnapshot), Snapshot_t(fullsnapshot){};
   SnapshotView_t(VectorView_t<HBTInt> &ids, Snapshot_t &fullsnapshot)
     : Ids(ids.data()), N(ids.size()), Snapshot(fullsnapshot), Snapshot_t(fullsnapshot){};
@@ -187,17 +187,17 @@ public:
 
 class ParticleSnapshot_t : public Snapshot_t
 {
-  typedef vector<HBTInt> IndexList_t;
+  typedef std::vector<HBTInt> IndexList_t;
 
   FlatIndexTable_t<HBTInt, HBTInt> FlatHash;
   MappedIndexTable_t<HBTInt, HBTInt> MappedHash;
   IndexTable_t<HBTInt, HBTInt> *ParticleHash;
 
   void ExchangeParticles(MpiWorker_t &world);
-  vector<HBTInt> PartitionParticles(MpiWorker_t &world);
+  std::vector<HBTInt> PartitionParticles(MpiWorker_t &world);
 
 public:
-  vector<Particle_t> Particles;
+  std::vector<Particle_t> Particles;
   HBTInt NumberOfParticlesOnAllNodes;
 
   ParticleSnapshot_t()
@@ -246,7 +246,7 @@ public:
   void AverageVelocity(HBTxyz &CoV, const HBTInt Particles[], HBTInt NumPart) const;
 
   template <class Halo_T>
-  void ExchangeHalos(MpiWorker_t &world, vector<Halo_T> &InHalos, vector<Halo_T> &OutHalos,
+  void ExchangeHalos(MpiWorker_t &world, std::vector<Halo_T> &InHalos, std::vector<Halo_T> &OutHalos,
                      MPI_Datatype MPI_Halo_Shell_Type) const;
 };
 inline HBTInt ParticleSnapshot_t::size() const

--- a/src/snapshot_exchanger.cpp
+++ b/src/snapshot_exchanger.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include <iostream>
-// #include <iomanip>
 #include <assert.h>
 #include <chrono>
 #include <cstdio>
@@ -24,14 +22,14 @@ inline int GetGrid(HBTReal x, HBTReal step, int dim)
     i = dim - 1;
   return i;
 }
-inline int AssignCell(HBTxyz &Pos, const HBTReal step[3], const vector<int> &dims)
+inline int AssignCell(HBTxyz &Pos, const HBTReal step[3], const std::vector<int> &dims)
 {
 #define GRIDtoRank(g0, g1, g2) (((g0) * dims[1] + (g1)) * dims[2] + (g2))
 #define GID(i) GetGrid(Pos[i], step[i], dims[i])
   return GRIDtoRank(GID(0), GID(1), GID(2));
 }
 
-vector<HBTInt> ParticleSnapshot_t::PartitionParticles(MpiWorker_t &world)
+std::vector<HBTInt> ParticleSnapshot_t::PartitionParticles(MpiWorker_t &world)
 {
   return sort_by_hash(Particles, world.size());
 }
@@ -56,15 +54,15 @@ void ParticleSnapshot_t::ExchangeParticles(MpiWorker_t &world)
     MPI_Allreduce(&np, &NumberOfParticlesOnAllNodes, 1, MPI_HBT_INT, MPI_SUM, world.Communicator);
   }
 
-  vector<HBTInt> SendOffsets = PartitionParticles(world);
+  std::vector<HBTInt> SendOffsets = PartitionParticles(world);
   SendOffsets.push_back(Particles.size());
-  vector<HBTInt> SendSizes(world.size(), 0);
+  std::vector<HBTInt> SendSizes(world.size(), 0);
   for (int i = 0; i < world.size(); i++)
     SendSizes[i] = SendOffsets[i + 1] - SendOffsets[i];
 
-  vector<HBTInt> ReceiveSizes(world.size(), 0), ReceiveOffsets(world.size());
+  std::vector<HBTInt> ReceiveSizes(world.size(), 0), ReceiveOffsets(world.size());
   MPI_Alltoall(SendSizes.data(), 1, MPI_HBT_INT, ReceiveSizes.data(), 1, MPI_HBT_INT, world.Communicator);
-  vector<Particle_t> ReceivedParticles;
+  std::vector<Particle_t> ReceivedParticles;
   ReceivedParticles.resize(CompileOffsets(ReceiveSizes, ReceiveOffsets));
 
 #ifndef NDEBUG

--- a/src/snapshot_number.h
+++ b/src/snapshot_number.h
@@ -61,7 +61,7 @@ inline int SnapshotNumber_t::GetSnapshotId(const int &snapshot_index) const
     return HBTConfig.SnapshotIdList[snapshot_index];
 }
 
-inline void SnapshotNumber_t::FormatSnapshotId(stringstream &ss)
+inline void SnapshotNumber_t::FormatSnapshotId(std::stringstream &ss)
 {
   ss << std::setw(3) << std::setfill('0') << SnapshotId;
 }

--- a/src/subhalo.cpp
+++ b/src/subhalo.cpp
@@ -9,23 +9,11 @@
 #include "snapshot_number.h"
 #include "subhalo.h"
 #include "particle_exchanger.h"
-/*
-void MemberShipTable_t::SubIdToTrackId(const SubhaloList_t& Subhalos)
-{
-   for(HBTInt i=0;i<AllMembers.size();i++)
-    AllMembers[i]=Subhalos[AllMembers[i]].TrackId;
-}
-void MemberShipTable_t::TrackIdToSubId(SubhaloList_t& Subhalos)
-{
-cout<<"Warning: TrackIdToSubId ToBe fully Implemented!\n";
-// exit(1);
-}
-*/
 
-void ExchangeSubHalos(MpiWorker_t &world, vector<Subhalo_t> &InHalos, vector<Subhalo_t> &OutHalos,
+void ExchangeSubHalos(MpiWorker_t &world, std::vector<Subhalo_t> &InHalos, std::vector<Subhalo_t> &OutHalos,
                       MPI_Datatype MPI_Halo_Shell_Type, const ParticleSnapshot_t &snap)
 {
-  typedef typename vector<Subhalo_t>::iterator HaloIterator_t;
+  typedef typename std::vector<Subhalo_t>::iterator HaloIterator_t;
   typedef HaloParticleIterator_t<HaloIterator_t> ParticleIterator_t;
   typedef HaloNestIterator_t<HaloIterator_t> NestIterator_t;
 
@@ -40,81 +28,6 @@ void ExchangeSubHalos(MpiWorker_t &world, vector<Subhalo_t> &InHalos, vector<Sub
       InHalos[i].AverageCoordinates();
     InHalos.swap(OutHalos);
   }
-  /*
-  vector <IdRank_t>TargetRank(InHalos.size());
-  DecideTargetProcessor(world.size(), InHalos, TargetRank);
-
-  //distribute halo shells
-    vector <int> SendHaloCounts(world.size(),0), RecvHaloCounts(world.size()), SendHaloDisps(world.size()),
-  RecvHaloDisps(world.size()); sort(TargetRank.begin(), TargetRank.end(), CompareRank); vector <Subhalo_t>
-  InHalosSorted(InHalos.size()); vector <HBTInt> InHaloSizes(InHalos.size()), InHaloNestSizes(InHalos.size());
-    for(HBTInt haloid=0;haloid<InHalos.size();haloid++)
-    {
-      InHalosSorted[haloid]=move(InHalos[TargetRank[haloid].Id]);
-      SendHaloCounts[TargetRank[haloid].Rank]++;
-      InHaloSizes[haloid]=InHalosSorted[haloid].Particles.size();
-      InHaloNestSizes[haloid]=InHalosSorted[haloid].NestedSubhalos.size();
-    }
-    MPI_Alltoall(SendHaloCounts.data(), 1, MPI_INT, RecvHaloCounts.data(), 1, MPI_INT, world.Communicator);
-    CompileOffsets(SendHaloCounts, SendHaloDisps);
-    HBTInt NumNewHalos=CompileOffsets(RecvHaloCounts, RecvHaloDisps);
-    OutHalos.resize(OutHalos.size()+NumNewHalos);
-    auto NewHalos=OutHalos.end()-NumNewHalos;
-    MPI_Alltoallv(InHalosSorted.data(), SendHaloCounts.data(), SendHaloDisps.data(), MPI_Halo_Shell_Type, &NewHalos[0],
-  RecvHaloCounts.data(), RecvHaloDisps.data(), MPI_Halo_Shell_Type, world.Communicator);
-  //resize receivehalos
-    vector <HBTInt> OutHaloSizes(NumNewHalos), OutHaloNestSizes(NumNewHalos);
-    MPI_Alltoallv(InHaloSizes.data(), SendHaloCounts.data(), SendHaloDisps.data(), MPI_HBT_INT, OutHaloSizes.data(),
-  RecvHaloCounts.data(), RecvHaloDisps.data(), MPI_HBT_INT, world.Communicator); MPI_Alltoallv(InHaloNestSizes.data(),
-  SendHaloCounts.data(), SendHaloDisps.data(), MPI_HBT_INT, OutHaloNestSizes.data(), RecvHaloCounts.data(),
-  RecvHaloDisps.data(), MPI_HBT_INT, world.Communicator); for(HBTInt i=0;i<NumNewHalos;i++)
-    {
-      NewHalos[i].Particles.resize(OutHaloSizes[i]);
-      NewHalos[i].NestedSubhalos.resize(OutHaloNestSizes[i]);
-    }
-
-    {
-    //distribute halo particles
-    MPI_Datatype MPI_HBT_Particle;
-    Particle_t().create_MPI_type(MPI_HBT_Particle);
-    //create combined iterator for each bunch of haloes
-    vector <ParticleIterator_t> InParticleIterator(world.size());
-    vector <ParticleIterator_t> OutParticleIterator(world.size());
-    for(int rank=0;rank<world.size();rank++)
-    {
-      InParticleIterator[rank].init(InHalosSorted.begin()+SendHaloDisps[rank],
-  InHalosSorted.begin()+SendHaloDisps[rank]+SendHaloCounts[rank]);
-      OutParticleIterator[rank].init(NewHalos+RecvHaloDisps[rank], NewHalos+RecvHaloDisps[rank]+RecvHaloCounts[rank]);
-    }
-    vector <HBTInt> InParticleCount(world.size(),0);
-    for(HBTInt i=0;i<InHalosSorted.size();i++)
-      InParticleCount[TargetRank[i].Rank]+=InHalosSorted[i].Particles.size();
-
-    MyAllToAll<Particle_t, ParticleIterator_t, ParticleIterator_t>(world, InParticleIterator, InParticleCount,
-  OutParticleIterator, MPI_HBT_Particle);
-
-    MPI_Type_free(&MPI_HBT_Particle);
-    }
-
-    {
-    //distribute nests
-    //create combined iterator for each bunch of haloes
-    vector <NestIterator_t> InNestIterator(world.size());
-    vector <NestIterator_t> OutNestIterator(world.size());
-    for(int rank=0;rank<world.size();rank++)
-    {
-      InNestIterator[rank].init(InHalosSorted.begin()+SendHaloDisps[rank],
-  InHalosSorted.begin()+SendHaloDisps[rank]+SendHaloCounts[rank]);
-      OutNestIterator[rank].init(NewHalos+RecvHaloDisps[rank], NewHalos+RecvHaloDisps[rank]+RecvHaloCounts[rank]);
-    }
-    vector <HBTInt> InNestCount(world.size(),0);
-    for(HBTInt i=0;i<InHalosSorted.size();i++)
-      InNestCount[TargetRank[i].Rank]+=InHalosSorted[i].NestedSubhalos.size();
-
-    MyAllToAll<HBTInt, NestIterator_t, NestIterator_t>(world, InNestIterator, InNestCount, OutNestIterator,
-  MPI_HBT_INT);
-    }
-    */
 }
 
 void SubhaloSnapshot_t::BuildMPIDataType()
@@ -289,7 +202,7 @@ void Subhalo_t::CalculateProfileProperties(const Snapshot_t &epoch)
 
   const HBTxyz &cen = ComovingMostBoundPosition; // most-bound particle as center.
 
-  vector<RadMassVel_t> prof(Nbound);
+  std::vector<RadMassVel_t> prof(Nbound);
 #pragma omp parallel if (Nbound > 100)
   {
 #pragma omp for
@@ -401,10 +314,10 @@ void Subhalo_t::CountParticleTypes()
 
   /* Used for finding TracerIndex for large (Nbound > 100) tracks */
 #pragma omp declare reduction(minPair:IndexParticleType_t : omp_out = firstIndex(omp_out, omp_in))                     \
-  initializer(omp_priv = IndexParticleType_t(numeric_limits<HBTInt>::max(), -1))
+  initializer(omp_priv = IndexParticleType_t(std::numeric_limits<HBTInt>::max(), -1))
 
   /* Initialise the value of the pair to identify specified tracer */
-  IndexParticleType_t Tracer_Index_ParticleType(numeric_limits<HBTInt>::max(), -1);
+  IndexParticleType_t Tracer_Index_ParticleType(std::numeric_limits<HBTInt>::max(), -1);
 
   for (int itype = 0; itype < TypeMax; itype++)
   {
@@ -415,8 +328,8 @@ void Subhalo_t::CountParticleTypes()
   {
 #pragma omp parallel
     {
-      vector<HBTInt> nboundtype(TypeMax, 0);
-      vector<float> mboundtype(TypeMax, 0.);
+      std::vector<HBTInt> nboundtype(TypeMax, 0);
+      std::vector<float> mboundtype(TypeMax, 0.);
 #pragma omp for reduction(minPair : Tracer_Index_ParticleType)
       for (HBTInt i = 0; i < Nbound; i++)
       {
@@ -490,7 +403,7 @@ HBTInt Subhalo_t::KickNullParticles()
     if (it->Id != SpecialConst::NullParticleId) // there will be consumed particles
     {
       if (it != it_save)
-        *it_save = move(*it);
+        *it_save = std::move(*it);
       ++it_save;
     }
   }
@@ -502,7 +415,7 @@ HBTInt Subhalo_t::KickNullParticles()
     if (it->Id != SpecialConst::NullParticleId) // there will be consumed particles
     {
       if (it != it_save)
-        *it_save = move(*it);
+        *it_save = std::move(*it);
       ++it_save;
     }
   }
@@ -537,7 +450,7 @@ void Subhalo_t::CountParticles()
     NboundType[itype]++;
     MboundType[itype] += it->Mass;
   }
-  Mbound = accumulate(begin(MboundType), end(MboundType), (HBTReal)0.);
+  Mbound = std::accumulate(std::begin(MboundType), std::end(MboundType), (HBTReal)0.);
 #endif
 }
 
@@ -545,7 +458,7 @@ void Subhalo_t::CountParticles()
   Return the IDs of the N most bound tracer particles.
   Will return non-tracers if there are not enough tracers.
 */
-vector<HBTInt> Subhalo_t::GetMostBoundTracerIds(HBTInt n)
+std::vector<HBTInt> Subhalo_t::GetMostBoundTracerIds(HBTInt n)
 {
 
   // Allocate the output vector

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -21,13 +21,13 @@ enum class SubReaderDepth_t
 };
 
 class Subhalo_t;
-typedef vector<Subhalo_t> SubhaloList_t;
+typedef std::vector<Subhalo_t> SubhaloList_t;
 
 class Subhalo_t
 {
 public:
-  typedef vector<Particle_t> ParticleList_t;
-  typedef vector<HBTInt> SubIdList_t;
+  typedef std::vector<Particle_t> ParticleList_t;
+  typedef std::vector<HBTInt> SubIdList_t;
   HBTInt TrackId;
   HBTInt Nbound;
   float Mbound;
@@ -92,8 +92,8 @@ public:
 
   /* Binding/potential energies of the particles bound to the subhalo. They are a separate instance from ParticleList_t
    * because they do not need communicating before unbinding. */
-  vector<float> ParticleBindingEnergies;
-  vector<float> ParticlePotentialEnergies;
+  std::vector<float> ParticleBindingEnergies;
+  std::vector<float> ParticlePotentialEnergies;
 
   SubIdList_t NestedSubhalos; // list of sub-in-subs.
 
@@ -169,7 +169,7 @@ public:
   void CountParticleTypes();
   HBTInt KickNullParticles();
   void CountParticles();
-  void LevelUpDetachedMembers(vector<Subhalo_t> &Subhalos);
+  void LevelUpDetachedMembers(std::vector<Subhalo_t> &Subhalos);
   // for merger
   void MergeTo(Subhalo_t &host);
   bool IsTrapped()
@@ -187,7 +187,7 @@ public:
 #ifdef CHECK_TRACER_INDEX
     if (TracerId != Particles[TracerIndex].Id)
     {
-      cerr << "Tracer particle ID is incorrect!" << endl;
+      cerr << "Tracer particle ID is incorrect!" << std::endl;
       abort();
     }
 #endif
@@ -206,7 +206,7 @@ public:
     }
 #endif
   }
-  vector<HBTInt> GetMostBoundTracerIds(HBTInt n);
+  std::vector<HBTInt> GetMostBoundTracerIds(HBTInt n);
 
 private:
   /* To determine number of most bound tracer particles used to estimate the
@@ -232,10 +232,10 @@ private:
   void CountEmptyGroups();
   /*avoid operating on the Mem_* below; use the public VectorViews whenever possible; only operate the Mem_* variables
    * when adjusting memory*/
-  vector<MemberList_t> Mem_SubGroups; // list of subhaloes inside each host halo, with the storage of each subgroup
+  std::vector<MemberList_t> Mem_SubGroups; // list of subhaloes inside each host halo, with the storage of each subgroup
                                       // mapped to a location in AllMembers
 public:
-  vector<HBTInt> AllMembers; // the complete list of all the subhaloes in SubGroups. (contains local subhaloid, i.e.,
+  std::vector<HBTInt> AllMembers; // the complete list of all the subhaloes in SubGroups. (contains local subhaloid, i.e.,
                              // the index of subhaloes in the local SubhaloSnapshot_t). do not resize this vector
                              // manually. resize only with ResizeAllMembers() function.
   VectorView_t<MemberList_t>
@@ -244,7 +244,7 @@ public:
                  // for the normal groups.
   HBTInt NBirth; // newly born halos, excluding fake halos
   HBTInt NFake;  // Fake (unbound) halos with no progenitors
-  vector<vector<HBTInt>> SubGroupsOfHeads; // list of top-level subhaloes in each halo
+  std::vector<std::vector<HBTInt>> SubGroupsOfHeads; // list of top-level subhaloes in each halo
 
   MemberShipTable_t() : Mem_SubGroups(), AllMembers(), SubGroups(), SubGroupsOfHeads(), NBirth(0), NFake(0)
   {
@@ -293,12 +293,12 @@ private:
   void GlobalizeTrackReferences();
   void NestSubhalos(MpiWorker_t &world);
   void MaskSubhalos();
-  vector<int> RootNestSize; // buffer variable for temporary use.
+  std::vector<int> RootNestSize; // buffer variable for temporary use.
   void FillDepthRecursive(HBTInt subid, int depth);
   void FillDepth();
   void SetNestedParentIds();
 
-  void HandleTracerlessSubhalos(MpiWorker_t &world, vector<Subhalo_t> &LocalSubhalos);
+  void HandleTracerlessSubhalos(MpiWorker_t &world, std::vector<Subhalo_t> &LocalSubhalos);
 
   /* Methods to print information of how the analysis of each output is going. */
   void PrintHostStatistics(MpiWorker_t &world);
@@ -329,8 +329,8 @@ public:
       H5Tclose(H5T_SubhaloInMem);
     My_Type_free(&MPI_HBT_SubhaloShell_t);
   }
-  string GetSubDir();
-  void GetSubFileName(string &filename, int iFile, const string &ftype = "Sub");
+  std::string GetSubDir();
+  void GetSubFileName(std::string &filename, int iFile, const std::string &ftype = "Sub");
   void Load(MpiWorker_t &world, int snapshot_index, const SubReaderDepth_t depth = SubReaderDepth_t::SubParticles);
   void Save(MpiWorker_t &world);
 

--- a/src/subhalo.h
+++ b/src/subhalo.h
@@ -187,7 +187,7 @@ public:
 #ifdef CHECK_TRACER_INDEX
     if (TracerId != Particles[TracerIndex].Id)
     {
-      cerr << "Tracer particle ID is incorrect!" << std::endl;
+      std::cerr << "Tracer particle ID is incorrect!" << std::endl;
       abort();
     }
 #endif

--- a/src/subhalo_merge.cpp
+++ b/src/subhalo_merge.cpp
@@ -107,14 +107,14 @@ void Subhalo_t::GetCorePhaseSpaceProperties()
   /* Initalize variables used to accumulate position, velocity, mass etc */
   HBTInt NumPart = 0;
   double msum = 0;
-  vector<double> pos(3, 0), pos2(3, 0);
-  vector<double> vel(3, 0), vel2(3, 0);
+  std::vector<double> pos(3, 0), pos2(3, 0);
+  std::vector<double> vel(3, 0), vel2(3, 0);
 
   /* How many particles we will use */
   HBTInt CoreSize = GetCoreSize();
 
   // Use first particle as reference point for box wrap
-  vector<double> origin(3, 0);
+  std::vector<double> origin(3, 0);
   if (HBTConfig.PeriodicBoundaryOn)
     for (int j = 0; j < 3; j++)
       origin[j] = Particles[0].ComovingPosition[j];
@@ -195,7 +195,7 @@ void Subhalo_t::MergeTo(Subhalo_t &host)
    * as we are guaranteed to not have duplicates between these two objects. */
   HBTInt np_new = host.Particles.size() + Nbound;
 
-  unordered_set<HBTInt> UniqueIds(np_new);
+  std::unordered_set<HBTInt> UniqueIds(np_new);
   for (auto &&p : host.Particles)
     UniqueIds.insert(p.Id);
   host.Particles.reserve(np_new);

--- a/src/subhalo_reassign_gas.cpp
+++ b/src/subhalo_reassign_gas.cpp
@@ -69,7 +69,7 @@ void SubhaloSnapshot_t::ReassignParticles(MpiWorker_t &world, HaloSnapshot_t &ha
   // Check if particle reassignment is enabled
   if(!HBTConfig.ReassignParticles) {
     if (world.rank() == 0)
-      cout << "  Not reassigning particles\n";
+      std::cout << "  Not reassigning particles\n";
     return;
   }
 

--- a/src/subhalo_tracking.cpp
+++ b/src/subhalo_tracking.cpp
@@ -222,7 +222,7 @@ inline HBTInt GetLocalHostId(HBTInt pid, const HaloSnapshot_t &halo_snap, const 
 
 /* Identify and store the particle IDs of the most bound NumTracerHostFinding
  * collisionless tracers. Used to identify host FOF groups. */
-void GetTracerIds(vector<HBTInt>::iterator particle_ids, const Subhalo_t &Subhalo)
+void GetTracerIds(std::vector<HBTInt>::iterator particle_ids, const Subhalo_t &Subhalo)
 {
   /* Initialise vector. This will make it so the code knows when to stop looking
    * for tracers, since orphans will have all but the first with NullParticleId */
@@ -248,14 +248,14 @@ void GetTracerIds(vector<HBTInt>::iterator particle_ids, const Subhalo_t &Subhal
   }
 
   /* Sanity checks */
-  assert(BoundRanking == min((int)Subhalo.Particles.size(),
+  assert(BoundRanking == std::min((int)Subhalo.Particles.size(),
                              HBTConfig.NumTracerHostFinding)); // We found all expected particles
 }
 
 /* Identify which FOF is host to the particles. If we have a value of -2, that
  * means the particle was not found in the particle information available to the
  * local rank. */
-bool GetTracerHosts(vector<HBTInt>::iterator particle_hosts, vector<HBTInt>::const_iterator particle_ids,
+bool GetTracerHosts(std::vector<HBTInt>::iterator particle_hosts, std::vector<HBTInt>::const_iterator particle_ids,
                     const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap)
 {
   /* Initialise vector. This will make it so the code knows when to stop looking
@@ -291,10 +291,10 @@ bool GetTracerHosts(vector<HBTInt>::iterator particle_hosts, vector<HBTInt>::con
  * NumTracerHostFinding most bound collisionless particles. This decision is
  * weighted by the binding energy ranking the particles had in the previous
  * output. */
-HBTInt DecideLocalHostId(vector<HBTInt>::const_iterator particle_hosts)
+HBTInt DecideLocalHostId(std::vector<HBTInt>::const_iterator particle_hosts)
 {
   /* To store unique host candidates, and the matching score. */
-  unordered_map<HBTInt, float> CandidateHosts;
+  std::unordered_map<HBTInt, float> CandidateHosts;
 
   /* Iterate over the particle list, and weight each candidate score by how
    * bound was the particle is */
@@ -328,10 +328,10 @@ HBTInt DecideLocalHostId(vector<HBTInt>::const_iterator particle_hosts)
  * NumTracerHostFinding most bound collisionless particles. This decision is
  * weighted by the binding energy ranking the particles had in the previous
  * output. Used during search across multiple tasks.*/
-IdRank_t DecideLocalHostId(vector<IdRank_t>::const_iterator particle_hosts)
+IdRank_t DecideLocalHostId(std::vector<IdRank_t>::const_iterator particle_hosts)
 {
   /* To store unique host candidates, their rank, and the matching score. */
-  unordered_map<HBTInt, float> CandidateHosts, CandidateHostRank;
+  std::unordered_map<HBTInt, float> CandidateHosts, CandidateHostRank;
 
   /* Iterate over the particle list, and weight each candidate score by how
    * bound was the particle is */
@@ -376,18 +376,18 @@ IdRank_t DecideLocalHostId(vector<IdRank_t>::const_iterator particle_hosts)
   return HostIdRank;
 }
 
-void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap, vector<Subhalo_t> &Subhalos,
-                    vector<Subhalo_t> &LocalSubhalos)
+void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap, std::vector<Subhalo_t> &Subhalos,
+                    std::vector<Subhalo_t> &LocalSubhalos)
 {
 #pragma omp parallel for
   for (HBTInt subid = 0; subid < Subhalos.size(); subid++)
   {
     /* Create a list of tracer particle IDs*/
-    vector<HBTInt> TracerParticleIds(HBTConfig.NumTracerHostFinding);
+    std::vector<HBTInt> TracerParticleIds(HBTConfig.NumTracerHostFinding);
     GetTracerIds(TracerParticleIds.begin(), Subhalos[subid]);
 
     /* Identify which FOFs those IDs are located in. */
-    vector<HBTInt> TracerHosts(HBTConfig.NumTracerHostFinding);
+    std::vector<HBTInt> TracerHosts(HBTConfig.NumTracerHostFinding);
     bool MakeDecision = GetTracerHosts(TracerHosts.begin(), TracerParticleIds.cbegin(), halo_snap, part_snap);
 
     /* If we found all tracers in the current rank, make a host decision.
@@ -402,23 +402,23 @@ void FindLocalHosts(const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &p
     if (Subhalos[subid].HostHaloId < 0) // Move all subhaloes
     {
       if (subid > nsub)
-        Subhalos[nsub] = move(Subhalos[subid]); // there should be a default move assignement operator.
+        Subhalos[nsub] = std::move(Subhalos[subid]); // there should be a default move assignement operator.
       nsub++;
     }
     else
-      LocalSubhalos.push_back(move(Subhalos[subid]));
+      LocalSubhalos.push_back(std::move(Subhalos[subid]));
   }
   Subhalos.resize(nsub);
 }
 
 void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_snap, const ParticleSnapshot_t &part_snap,
-                    VectorView_t<Subhalo_t> &Subhalos, vector<Subhalo_t> &LocalSubhalos,
+                    VectorView_t<Subhalo_t> &Subhalos, std::vector<Subhalo_t> &LocalSubhalos,
                     MPI_Datatype MPI_Subhalo_Shell_Type)
 /*scatter Subhalos from process root to LocalSubhalos in every other process
  Note Subalos are "moved", so are in a unspecified state upon return.*/
 {
   int thisrank = world.rank();
-  vector<HBTInt> TrackParticleIds;
+  std::vector<HBTInt> TrackParticleIds;
   HBTInt NumSubhalos;
 
   // broadcast trackparticles
@@ -426,15 +426,15 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   {
     NumSubhalos = Subhalos.size();
     if (NumSubhalos * HBTConfig.NumTracerHostFinding > INT_MAX)
-      throw runtime_error("Error: in FindOtherHosts(), sending more subhaloes than INT_MAX will cause MPI message to "
-                          "overflow. Please try more MPI threads. aborting.\n");
+      throw std::runtime_error("Error: in FindOtherHosts(), sending more subhaloes than INT_MAX will cause MPI message to "
+                               "overflow. Please try more MPI threads. aborting.\n");
   }
   MPI_Bcast(&NumSubhalos, 1, MPI_HBT_INT, root, world.Communicator);
 
   /* Create vector to hold the IDs of particles to look out for. We assign a
    * conservative value of NumTracerHostFinding particles per subhalo, even
    * though we may have orphans in the mix (only require one entry) */
-  vector<HBTInt> TracerParticleIds(NumSubhalos * HBTConfig.NumTracerHostFinding);
+  std::vector<HBTInt> TracerParticleIds(NumSubhalos * HBTConfig.NumTracerHostFinding);
 
   /* Populate the vectors with the ParticleIDs of tracers belonging to the subhaloes
    * of the root task */
@@ -449,7 +449,7 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   MPI_Bcast(TracerParticleIds.data(), TracerParticleIds.size(), MPI_HBT_INT, root, world.Communicator);
 
   /* To find hosts in the current task  */
-  vector<IdRank_t> LocalHostRankPairs(NumSubhalos * HBTConfig.NumTracerHostFinding, IdRank_t{-2, thisrank});
+  std::vector<IdRank_t> LocalHostRankPairs(NumSubhalos * HBTConfig.NumTracerHostFinding, IdRank_t{-2, thisrank});
 
 #pragma omp parallel for if (NumSubhalos > 20)
   for (HBTInt i = 0; i < NumSubhalos; i++)
@@ -457,7 +457,7 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
     unsigned long long offset = HBTConfig.NumTracerHostFinding * i; // Start of subhalo
 
     /* Identify which FOFs those IDs are located in. */
-    vector<HBTInt> TracerHosts(HBTConfig.NumTracerHostFinding);
+    std::vector<HBTInt> TracerHosts(HBTConfig.NumTracerHostFinding);
     GetTracerHosts(TracerHosts.begin(), TracerParticleIds.cbegin() + offset, halo_snap, part_snap);
 
     /* Copy over to the vector-struct */
@@ -466,12 +466,12 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   }
 
   /* Communicate to all tasks */
-  vector<IdRank_t> GlobalHostRankPairs(NumSubhalos * HBTConfig.NumTracerHostFinding);
+  std::vector<IdRank_t> GlobalHostRankPairs(NumSubhalos * HBTConfig.NumTracerHostFinding);
   MPI_Allreduce(LocalHostRankPairs.data(), GlobalHostRankPairs.data(), LocalHostRankPairs.size(), MPI_HBTRankPair,
                 MPI_MAXLOC, world.Communicator);
 
   /* Score each candidate, and identify the rank it lives in */
-  vector<IdRank_t> GlobalHostIds(NumSubhalos);
+  std::vector<IdRank_t> GlobalHostIds(NumSubhalos);
 #pragma omp parallel for if (NumSubhalos > 20)
   for (HBTInt i = 0; i < NumSubhalos; i++)
   {
@@ -483,11 +483,11 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   // send particles and nests; no scatterw, do it manually
   MPI_Datatype MPI_HBT_Particle;
   Particle_t().create_MPI_type(MPI_HBT_Particle);
-  vector<vector<int>> SendSizes(world.size()), SendNestSizes(world.size());
-  vector<MPI_Request> Req0, Req1, ReqNest0, ReqNest1;
+  std::vector<std::vector<int>> SendSizes(world.size()), SendNestSizes(world.size());
+  std::vector<MPI_Request> Req0, Req1, ReqNest0, ReqNest1;
   if (thisrank == root)
   {
-    vector<vector<MPI_Aint>> SendBuffers(world.size()), SendNestBuffers(world.size());
+    std::vector<std::vector<MPI_Aint>> SendBuffers(world.size()), SendNestBuffers(world.size());
     for (HBTInt subid = 0; subid < NumSubhalos; subid++) // packing
     {
       int rank = GlobalHostIds[subid].Rank;
@@ -530,8 +530,8 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
     }
   }
   // receive on every process, including root
-  vector<MPI_Aint> ReceiveBuffer, ReceiveNestBuffer;
-  vector<int> ReceiveSize, ReceiveNestSize;
+  std::vector<MPI_Aint> ReceiveBuffer, ReceiveNestBuffer;
+  std::vector<int> ReceiveSize, ReceiveNestSize;
   int NumNewSubs;
   MPI_Status stat;
   MPI_Probe(root, 0, world.Communicator, &stat);
@@ -584,8 +584,8 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
   }
 
   // copy other properties
-  vector<int> Counts(world.size()), Disps(world.size());
-  vector<Subhalo_t> TmpHalos;
+  std::vector<int> Counts(world.size()), Disps(world.size());
+  std::vector<Subhalo_t> TmpHalos;
   if (world.rank() == root)
   { // reuse GlobalHostIds for sorting
     for (HBTInt subid = 0; subid < Subhalos.size(); subid++)
@@ -597,7 +597,7 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
     stable_sort(GlobalHostIds.begin(), GlobalHostIds.end(), CompareRank);
     TmpHalos.resize(Subhalos.size());
     for (HBTInt subid = 0; subid < Subhalos.size(); subid++)
-      TmpHalos[subid] = move(Subhalos[GlobalHostIds[subid].Id]);
+      TmpHalos[subid] = std::move(Subhalos[GlobalHostIds[subid].Id]);
     // 		Subhalos[GlobalHostIds[subid].n].MoveTo(TmpHalos[subid], false);
     for (int rank = 0; rank < world.size(); rank++)
       Counts[rank] = SendSizes[rank].size();
@@ -608,8 +608,8 @@ void FindOtherHosts(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_sna
 }
 
 void FindOtherHostsSafely(MpiWorker_t &world, int root, const HaloSnapshot_t &halo_snap,
-                          const ParticleSnapshot_t &part_snap, vector<Subhalo_t> &Subhalos,
-                          vector<Subhalo_t> &LocalSubhalos, MPI_Datatype MPI_Subhalo_Shell_Type)
+                          const ParticleSnapshot_t &part_snap, std::vector<Subhalo_t> &Subhalos,
+                          std::vector<Subhalo_t> &LocalSubhalos, MPI_Datatype MPI_Subhalo_Shell_Type)
 /*break Subhalos into small chunks and then FindOtherHosts() for them, to avoid overflow in MPI message size*/
 {
   const int MaxChunkSize = 1024 * 1024;
@@ -665,7 +665,7 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
   ParallelizeHaloes = halo_snap.NumPartOfLargestHalo < 0.1 * halo_snap.TotNumberOfParticles; // no dominating objects
 
   /* To hold subhaloes with updated information. */
-  vector<Subhalo_t> LocalSubhalos;
+  std::vector<Subhalo_t> LocalSubhalos;
   LocalSubhalos.reserve(Subhalos.size());
 
   /* Creates ParticleID - HostHalo information, local to the task. */
@@ -693,7 +693,7 @@ void SubhaloSnapshot_t::AssignHosts(MpiWorker_t &world, HaloSnapshot_t &halo_sna
 /* This function iterates over Subhalos and assigns a default HostHaloId (-1) to all Subhalos
  * whose tracer particles were not found. If any such cases are present in the simulation, a
  * warning is printed. */
-void SubhaloSnapshot_t::HandleTracerlessSubhalos(MpiWorker_t &world, vector<Subhalo_t> &LocalSubhalos)
+void SubhaloSnapshot_t::HandleTracerlessSubhalos(MpiWorker_t &world, std::vector<Subhalo_t> &LocalSubhalos)
 {
   HBTInt NumberTracerlessSubhalos = 0;
 
@@ -793,7 +793,7 @@ void SubhaloSnapshot_t::DecideCentrals(const HaloSnapshot_t &halo_snap)
           }
         }
         if (icenter)
-          swap(List[0], List[icenter]);
+          std::swap(List[0], List[icenter]);
       }
     }
   }
@@ -919,11 +919,11 @@ void SubhaloSnapshot_t::AssignNewTrackIds(MpiWorker_t &world, const HaloSnapshot
    * MPI_Gatherv. If we have more new subhaloes than INT_MAX per rank or across
    * all ranks, an overflow will happen. */
   if (MemberTable.NBirth > INT_MAX)
-    throw runtime_error("Error: in AssignNewTrackIds(). The number of new subhaloes in a single rank is larger than INT_MAX. "
-                        "It will cause required MPI communications to overflow. Please try more MPI threads. Aborting.\n");
+    throw std::runtime_error("Error: in AssignNewTrackIds(). The number of new subhaloes in a single rank is larger than INT_MAX. "
+                             "It will cause required MPI communications to overflow. Please try more MPI threads. Aborting.\n");
   if (TotalNBirth > INT_MAX)
-    throw runtime_error("Error: in AssignNewTrackIds(). The number of new subhaloes across all ranks is larger than INT_MAX. "
-                        "It will cause required MPI communications to overflow. Please try more MPI threads. Aborting.\n");
+    throw std::runtime_error("Error: in AssignNewTrackIds(). The number of new subhaloes across all ranks is larger than INT_MAX. "
+                             "It will cause required MPI communications to overflow. Please try more MPI threads. Aborting.\n");
   // NOTE: I suspect this will never trigger, since forming INT_MAX new subhaloes
   // in a single snapshot is extremely unlikely. IF it does happen, we can split
   // MPI communication into chunks to handle this.
@@ -975,7 +975,7 @@ void SubhaloSnapshot_t::PurgeMostBoundParticles()
   for (HBTInt i = -1; i < MemberTable.SubGroups.size(); i++)
   {
     auto &Group = MemberTable.SubGroups[i];
-    unordered_set<HBTInt> ExclusionList;
+    std::unordered_set<HBTInt> ExclusionList;
     {
       HBTInt np = 0;
       for (auto &&subid : Group)
@@ -996,7 +996,7 @@ void SubhaloSnapshot_t::PurgeMostBoundParticles()
             {
               copyHBTxyz(subhalo.ComovingMostBoundPosition, p.ComovingPosition);
               copyHBTxyz(subhalo.PhysicalMostBoundVelocity, p.GetPhysicalVelocity());
-              swap(subhalo.Particles[0], p);
+              std::swap(subhalo.Particles[0], p);
               break;
             }
           }
@@ -1044,7 +1044,7 @@ void SubhaloSnapshot_t::LocalizeNestedIds(MpiWorker_t &world)
   TrackHash.Fill(Ids, SpecialConst::NullTrackId);
 
   // collect lost tracks
-  vector<HBTInt> DissociatedTracks;
+  std::vector<HBTInt> DissociatedTracks;
   for (auto &&subhalo : Subhalos)
   {
     auto &nests = subhalo.NestedSubhalos;
@@ -1067,13 +1067,13 @@ void SubhaloSnapshot_t::LocalizeNestedIds(MpiWorker_t &world)
   }
 
   // distribute, locate and levelup DissociatedTracks
-  vector<HBTInt> ReceivedTracks;
+  std::vector<HBTInt> ReceivedTracks;
   for (int root = 0; root < world.size(); root++)
   {
     HBTInt stacksize = DissociatedTracks.size();
     MPI_Bcast(&stacksize, 1, MPI_HBT_INT, root, world.Communicator);
     ReceivedTracks.resize(stacksize);
-    MyBcast<HBTInt, vector<HBTInt>::iterator, vector<HBTInt>::iterator>(
+    MyBcast<HBTInt, std::vector<HBTInt>::iterator, std::vector<HBTInt>::iterator>(
       world, DissociatedTracks.begin(), ReceivedTracks.begin(), stacksize, MPI_HBT_INT, root);
     if (world.rank() != root)
     {
@@ -1173,7 +1173,7 @@ void SubhaloSnapshot_t::LevelUpDetachedSubhalos()
  * assign rank=0 to subhaloes that has drifted away from the hosthalo of its host-subhalo.
  */
 {
-  vector<char> IsHeadSub(Subhalos.size());
+  std::vector<char> IsHeadSub(Subhalos.size());
 // record head list first, since the ranks are modified during LevelUpDetachedMembers().
 #pragma omp parallel
   {
@@ -1204,7 +1204,7 @@ void SubhaloSnapshot_t::LevelUpDetachedSubhalos()
   }
 }
 
-void Subhalo_t::LevelUpDetachedMembers(vector<Subhalo_t> &Subhalos)
+void Subhalo_t::LevelUpDetachedMembers(std::vector<Subhalo_t> &Subhalos)
 {
   HBTInt isave = 0;
   for (HBTInt i = 0; i < NestedSubhalos.size(); i++)
@@ -1233,7 +1233,7 @@ void Subhalo_t::LevelUpDetachedMembers(vector<Subhalo_t> &Subhalos)
 class SubhaloMasker_t
 {
 public:
-  unordered_set<HBTInt> ExclusionList;
+  std::unordered_set<HBTInt> ExclusionList;
 
   SubhaloMasker_t(HBTInt np_guess)
   {
@@ -1241,7 +1241,7 @@ public:
   }
   /* This routine masks particles by giving preference to subhaloes deeper in
    * the hierarchy. */
-  void Mask(HBTInt subid, vector<Subhalo_t> &Subhalos, int SnapshotId)
+  void Mask(HBTInt subid, std::vector<Subhalo_t> &Subhalos, int SnapshotId)
   {
     auto &subhalo = Subhalos[subid];
     for (auto nestedid :
@@ -1262,14 +1262,14 @@ public:
       if (insert_status.second) // inserted, meaning not excluded
       {
         if (it != it_save)
-          *it_save = move(*it);
+          *it_save = std::move(*it);
         ++it_save;
       }
     }
     subhalo.Particles.resize(it_save - it_begin);
   }
 
-  HBTInt EstimateListSize(HBTInt subid, vector<Subhalo_t> &Subhalos,
+  HBTInt EstimateListSize(HBTInt subid, std::vector<Subhalo_t> &Subhalos,
                           const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
   {
 
@@ -1285,7 +1285,7 @@ public:
     return TotalSize;
   }
 
-  void CleanSource(HBTInt subid, vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
+  void CleanSource(HBTInt subid, std::vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
   {
     /* Mask the 10 most bound tracer particles of every resolved subhalo in the
      * tree. We do this to not encounter issues during host finding. */
@@ -1298,7 +1298,7 @@ public:
 
   /* This routine masks particles by giving priority to subhaloes shallower
    * in the hierarchy. */
-  void MaskTopBottom(HBTInt subid, vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
+  void MaskTopBottom(HBTInt subid, std::vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
   {
     /* We perform the masking first */
     auto &subhalo = Subhalos[subid];
@@ -1355,7 +1355,7 @@ public:
 
   /* This routine masks particles by giving priority to subhaloes deeper
    * in the hierarchy. */
-  void MaskBottomTop(HBTInt subid, vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
+  void MaskBottomTop(HBTInt subid, std::vector<Subhalo_t> &Subhalos, const MappedIndexTable_t<HBTInt, HBTInt> &TrackHash)
   {
     auto &subhalo = Subhalos[subid];
 
@@ -1387,7 +1387,7 @@ public:
       if (insert_status.second) // inserted, meaning not excluded
       {
         if (it != it_save)
-          *it_save = move(*it);
+          *it_save = std::move(*it);
         ++it_save;
       }
       /* Bound particle excluded; we will need to update Nbound. */

--- a/src/subhalo_unbind.cpp
+++ b/src/subhalo_unbind.cpp
@@ -32,7 +32,7 @@ inline bool IsNotSubsampleParticleType(const Particle_t &a)
 
 /* Separates unbound particles from bound particles by placing them at the end
  * of Elist */
-static HBTInt RemoveUnboundParticles(vector<ParticleEnergy_t> &Elist, const size_t NumPart)
+static HBTInt RemoveUnboundParticles(std::vector<ParticleEnergy_t> &Elist, const size_t NumPart)
 {
   /* Separate bound from unbound particles. Stable partition since we want to
    * keep original relative ordering (bound particles that cannot be subsampled
@@ -52,11 +52,11 @@ class EnergySnapshot_t : public Snapshot_t
     return Elist[i].ParticleIndex;
   }
 
-  vector<HBTReal> MassUpscaleFactor;
+  std::vector<HBTReal> MassUpscaleFactor;
 
 public:
   ParticleEnergy_t *Elist;
-  typedef vector<Particle_t> ParticleList_t;
+  typedef std::vector<Particle_t> ParticleList_t;
   HBTInt N;
   const ParticleList_t &Particles;
 
@@ -398,7 +398,7 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
   auto &Elist = ESnap.Elist;
   auto &Particles = ESnap.Particles;
   tree.Build(ESnap, Size);
-  vector<ParticleEnergy_t> Einner(Size);
+  std::vector<ParticleEnergy_t> Einner(Size);
 #pragma omp parallel if (Size > 100)
   {
 #pragma omp for
@@ -427,7 +427,7 @@ inline void RefineBindingEnergyOrder(EnergySnapshot_t &ESnap, HBTInt Size, Gravi
 /* Randomly shuffles the particles whose type are eligible to be subsampled
  * during unbinding. Particles types that are not eligible will be placed at the
  * start of the vector. */
-HBTInt PrepareParticlesForSubsampling(vector<Particle_t> &Particles)
+HBTInt PrepareParticlesForSubsampling(std::vector<Particle_t> &Particles)
 {
   /* We first partition the particle vector into those which we will
    * subsample and those which we will not. */
@@ -443,7 +443,7 @@ HBTInt PrepareParticlesForSubsampling(vector<Particle_t> &Particles)
 }
 
 /* Counts how many bound particles are not eligible to be subsampled. */
-HBTInt CountUnsampledParticles(const vector<ParticleEnergy_t> &Elist, const vector<Particle_t> &Particles, const HBTInt &OldNsubsample)
+HBTInt CountUnsampledParticles(const std::vector<ParticleEnergy_t> &Elist, const std::vector<Particle_t> &Particles, const HBTInt &OldNsubsample)
 {
   HBTInt NewNunsample = 0;
   for (HBTInt i = 0; i < OldNsubsample; i++)
@@ -525,7 +525,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
 
   /* This vector stores the original ordering of particles, and will later store
    * their binding energies. */
-  vector<ParticleEnergy_t> Elist(Particles.size());
+  std::vector<ParticleEnergy_t> Elist(Particles.size());
   for (HBTInt i = 0; i < Particles.size(); i++)
     Elist[i].ParticleIndex = i;
 
@@ -723,7 +723,7 @@ void Subhalo_t::Unbind(const Snapshot_t &epoch)
          * would be limited to the (MaxSampleSize / Nbound) fraction of most bound particles, whose ranking can be
          * extremely sensitive to the randomness used during unbinding. */
         HBTInt SampleSizeCenterRefinement =
-          max(MaxSampleSize, static_cast<HBTInt>(HBTConfig.BoundFractionCenterRefinement * Nbound));
+          std::max(MaxSampleSize, static_cast<HBTInt>(HBTConfig.BoundFractionCenterRefinement * Nbound));
 
         /* Computes self-binding energy of the SampleSizeCenterRefinement most bound
          * particles, and sorts them according to their binding energy. */

--- a/src/subhalo_update_mostbound.cpp
+++ b/src/subhalo_update_mostbound.cpp
@@ -25,7 +25,7 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
 
   // Make an array containing only zero sized subhalos and set each subhalo
   // to contain one particle with it's most bound particle ID.
-  vector<Subhalo_t> ZeroSizeSubhalo(nr_zero);
+  std::vector<Subhalo_t> ZeroSizeSubhalo(nr_zero);
   nr_zero = 0;
   for (auto &&sub : Subhalos)
   {
@@ -34,7 +34,7 @@ void SubhaloSnapshot_t::UpdateMostBoundPosition(MpiWorker_t &world, const Partic
       if (sub.MostBoundParticleId == SpecialConst::NullParticleId)
       {
         // I think this should be impossible: all tracks should have been resolved initially
-        cout << "Zero size subhalo has never been assigned a most bound particle ID!" << endl;
+        std::cout << "Zero size subhalo has never been assigned a most bound particle ID!" << std::endl;
         MPI_Abort(MPI_COMM_WORLD, 1);
       }
       ZeroSizeSubhalo[nr_zero] = sub;

--- a/src/test/testHBTxyz.cpp
+++ b/src/test/testHBTxyz.cpp
@@ -1,6 +1,5 @@
 #include <array>
 #include <iostream>
-// #include "../datatypes.h"
 template <class T>
 class XYZ
 {

--- a/src/test/testHBTxyz2.cpp
+++ b/src/test/testHBTxyz2.cpp
@@ -66,13 +66,13 @@ int main()
   std::cout << x << y << z << a << "\n";
 
   a = b;
-  cout << a << b << &a << "," << &b << endl;
-  vector<HBTxyz> v;
+  std::cout << a << b << &a << "," << &b << std::endl;
+  std::vector<HBTxyz> v;
   float data[] = {1, 2, 3, 4, 5, 6};
   //   v.assign((float (*)[3])data, (float (*)[3])data+2);
   v.resize(2);
   copy(data, data + 6, (HBTReal *)v.data());
-  cout << v[0] << v[1] << endl;
-  cout << &a << ',' << a.data() << endl;
+  std::cout << v[0] << v[1] << std::endl;
+  std::cout << &a << ',' << a.data() << std::endl;
   return 0;
 }

--- a/src/test/test_VecAllToAll.cpp
+++ b/src/test/test_VecAllToAll.cpp
@@ -8,23 +8,23 @@ int main(int argc, char **argv)
   mpi::environment env;
   mpi::communicator world;
 
-  vector<vector<int>> Send(world.size()), Receive(world.size());
+  std::vector<vector<int>> Send(world.size()), Receive(world.size());
   for (int i = 0; i < world.size(); i++)
     Send[i].assign(i, world.rank());
 
   VectorAllToAll(world, Send, Receive, MPI_INT);
   for (int i = 0; i < world.size(); i++)
   {
-    cout << world.rank() << ": send " << Send[i].size() << " elements to " << i << ": ";
+    std::cout << world.rank() << ": send " << Send[i].size() << " elements to " << i << ": ";
     copy(Send[i].cbegin(), Send[i].cend(), ostream_iterator<int>(cout, ", "));
-    cout << endl;
+    std::cout << std::endl;
   }
 
   for (int i = 0; i < world.size(); i++)
   {
-    cout << world.rank() << ": receive " << Receive[i].size() << " elements from " << i << ": ";
+    std::cout << world.rank() << ": receive " << Receive[i].size() << " elements from " << i << ": ";
     copy(Receive[i].cbegin(), Receive[i].cend(), ostream_iterator<int>(cout, ", "));
-    cout << endl;
+    std::cout << std::endl;
   }
 
   return 0;

--- a/src/test/test_accumulate.cpp
+++ b/src/test/test_accumulate.cpp
@@ -4,13 +4,13 @@
 using namespace std;
 int main()
 {
-  vector<int> x(10, 1);
+  std::vector<int> x(10, 1);
   int s = 0;
   s = accumulate(x.begin(), x.end(), s);
-  cout << s << endl;
+  std::cout << s << std::endl;
 
   s = accumulate(x.begin() + 1, x.begin() + 5, s);
-  cout << s << endl;
+  std::cout << s << std::endl;
 
   int init = 100;
   int numbers[] = {10, 20, 30};

--- a/src/test/test_boostmpi_mem.cpp
+++ b/src/test/test_boostmpi_mem.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
   mpi::communicator world;
 
 #define MSG_LEN 100000
-  vector<int> sendbuf(MSG_LEN, 1), recvbuf(MSG_LEN);
+  std::vector<int> sendbuf(MSG_LEN, 1), recvbuf(MSG_LEN);
 
 #define USE_BOOST
 
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 #endif
 
   if (world.rank() == 1)
-    cout << "Data received: " << recvbuf[0] << "," << recvbuf[1] << "...\n";
+    std::cout << "Data received: " << recvbuf[0] << "," << recvbuf[1] << "...\n";
 
   return 0;
 }

--- a/src/test/test_boostmpi_partialsend.cpp
+++ b/src/test/test_boostmpi_partialsend.cpp
@@ -11,7 +11,7 @@ namespace mpi = boost::mpi;
 struct TestStruct_t
 {
   int a;
-  vector<int> c;
+  std::vector<int> c;
   double b;
   TestStruct_t() : a(0), b(0), c(2, 1)
   {
@@ -28,7 +28,7 @@ private:
   }
 };
 BOOST_IS_MPI_DATATYPE(TestStruct_t)
-std::ostream &operator<<(std::ostream &o, vector<TestStruct_t> &x)
+std::ostream &operator<<(std::ostream &o, std::vector<TestStruct_t> &x)
 {
   for (auto &&a : x)
   {
@@ -48,21 +48,21 @@ int main(int argc, char **argv)
   mpi::communicator world;
 
 #define MSG_LEN 3
-  vector<TestStruct_t> sendbuf(MSG_LEN), recvbuf;
+  std::vector<TestStruct_t> sendbuf(MSG_LEN), recvbuf;
 
   if (world.rank() == 0)
   {
     sendbuf[1].a = 1;
     sendbuf[2].b = 2;
     sendbuf[1].c.push_back(-1);
-    cout << sendbuf << endl;
+    std::cout << sendbuf << std::endl;
     world.send(1, 0, sendbuf);
   }
   else if (world.rank() == 1)
     world.recv(0, 0, recvbuf);
 
   if (world.rank() == 1)
-    cout << recvbuf.size() << " elements received: " << recvbuf << "\n";
+    std::cout << recvbuf.size() << " elements received: " << recvbuf << "\n";
 
   return 0;
 }

--- a/src/test/test_boostmpi_sendvec.cpp
+++ b/src/test/test_boostmpi_sendvec.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
   mpi::communicator world;
 
 #define MSG_LEN 100
-  vector<int> sendbuf(MSG_LEN, 1), recvbuf(MSG_LEN);
+  std::vector<int> sendbuf(MSG_LEN, 1), recvbuf(MSG_LEN);
 
   if (world.rank() == 0)
     world.send(1, 0, sendbuf.data(), sendbuf.size());
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
     world.recv(0, 0, recvbuf.data(), recvbuf.size());
 
   if (world.rank() == 1)
-    cout << recvbuf.size() << " elements received: " << recvbuf[0] << "," << recvbuf[1] << "...\n";
+    std::cout << recvbuf.size() << " elements received: " << recvbuf[0] << "," << recvbuf[1] << "...\n";
 
   return 0;
 }

--- a/src/test/test_boostmpi_serialize.cpp
+++ b/src/test/test_boostmpi_serialize.cpp
@@ -1,7 +1,6 @@
 using namespace std;
 #include <iostream>
 #include <string>
-// #include "mpi.h"
 
 #include <boost/mpi.hpp>
 namespace mpi = boost::mpi;
@@ -12,7 +11,7 @@ int main(int argc, char **argv)
   mpi::communicator world;
 
 #define MSG_LEN 1000000
-  vector<int> sendbuf(MSG_LEN, 1), recvbuf(MSG_LEN);
+  std::vector<int> sendbuf(MSG_LEN, 1), recvbuf(MSG_LEN);
 
   MPI_Comm comm = world;
   if (world.rank() == 0)
@@ -24,7 +23,7 @@ int main(int argc, char **argv)
     int sendsize = static_cast<int>(oa.size());
     MPI_Send(&sendsize, 1, MPI_INT, 1, 0, comm);
     MPI_Ssend(sendptr, sendsize, MPI_PACKED, 1, 0, comm);
-    cout << sendsize << "," << oa.size() << endl;
+    std::cout << sendsize << "," << oa.size() << std::endl;
   }
   else if (world.rank() == 1)
   {
@@ -35,7 +34,7 @@ int main(int argc, char **argv)
     auto recvptr = ia.address();
     MPI_Recv(recvptr, recvsize, MPI_PACKED, 0, 0, comm, MPI_STATUS_IGNORE);
     ia >> recvbuf;
-    cout << "Data received: " << recvbuf[0] << "," << recvbuf[1] << "...\n";
+    std::cout << "Data received: " << recvbuf[0] << "," << recvbuf[1] << "...\n";
   }
 
   return 0;

--- a/src/test/test_closestfactor.cpp
+++ b/src/test/test_closestfactor.cpp
@@ -5,7 +5,7 @@
 int main(int argc, char **argv)
 {
 #define test(x, y)                                                                                                     \
-  cout << x << "," << y << " : " << ClosestFactors(x, y) << endl;                                                      \
+  std::cout << x << "," << y << " : " << ClosestFactors(x, y) << std::endl;                                                      \
   ;
   /*
 test(10,3);

--- a/src/test/test_getenv.cpp
+++ b/src/test/test_getenv.cpp
@@ -7,18 +7,18 @@ using namespace std;
 int main(int argc, char **argv)
 {
 
-  string dir = ".";
+  std::string dir = ".";
   char *versionstr = getenv("USER");
   if (versionstr)
   {
-    cout << dir + "/VER" + versionstr;
+    std::cout << dir + "/VER" + versionstr;
     ofstream version_file(dir + "/VER" + versionstr, fstream::trunc);
     // 	version_file<<versionstr;
     // 	version_file.close();
   }
   else
   {
-    cout << "HBT_VERSION not specified" << endl;
+    std::cout << "HBT_VERSION not specified" << std::endl;
   }
 
   return 0;

--- a/src/test/test_h5compound.cpp
+++ b/src/test/test_h5compound.cpp
@@ -37,7 +37,6 @@ using std::vector;
 #include "H5Cpp.h"
 #include "hdf5.h"
 #include "hdf5_hl.h"
-// #include "H5VarLenType.h"
 
 #ifndef H5_NO_NAMESPACE
 using namespace H5;
@@ -151,10 +150,10 @@ int main(void)
      */
 #define ShowField(s, x)                                                                                                \
   {                                                                                                                    \
-    cout << endl << "Field " << #x << " : " << endl;                                                                   \
+    std::cout << std::endl << "Field " << #x << " : " << std::endl;                                                                   \
     for (i = 0; i < LENGTH; i++)                                                                                       \
-      cout << s[i].x << " ";                                                                                           \
-    cout << endl;                                                                                                      \
+      std::cout << s[i].x << " ";                                                                                           \
+    std::cout << std::endl;                                                                                                      \
   }
     ShowField(s2, a);
     ShowField(s2, c);
@@ -175,10 +174,10 @@ int main(void)
     /*
      * Display the field
      */
-    cout << endl << "Field b : " << endl;
+    std::cout << std::endl << "Field b : " << std::endl;
     for (i = 0; i < LENGTH; i++)
-      cout << sf[i] << " ";
-    cout << endl;
+      std::cout << sf[i] << " ";
+    std::cout << std::endl;
 
     struct s3_t
     {
@@ -187,7 +186,7 @@ int main(void)
       int a;
       int d;
       float x[3];
-      vector<int> i; // this invalidates POD requirement of s3_t
+      std::vector<int> i; // this invalidates POD requirement of s3_t
       // 		float *f;
       // 		s2_t *s2;
       //  		CompType mtype2;
@@ -204,12 +203,12 @@ int main(void)
       }
     };
     ct_t mtype3container;
-    cout << mtype3container.getsize() << endl;
+    std::cout << mtype3container.getsize() << std::endl;
     VarLenType vlt_i(&PredType::NATIVE_INT);
-    cout << "s3_t size=" << sizeof(s3_t) << endl;
-    cout << "vecotor i size=" << sizeof(vector<int>) << endl;
-    vector<int> ii(10);
-    cout << "vector ii size=" << sizeof(ii) << endl;
+    std::cout << "s3_t size=" << sizeof(s3_t) << std::endl;
+    std::cout << "vecotor i size=" << sizeof(vector<int>) << std::endl;
+    std::vector<int> ii(10);
+    std::cout << "vector ii size=" << sizeof(ii) << std::endl;
     CompType mtype3(sizeof(s3_t));
     mtype3.insertMember("a", HOFFSET(s3_t, a), PredType::NATIVE_INT);
     //       mtype3.insertMember(MEMBER2, HOFFSET(s3_t, b), PredType::NATIVE_FLOAT);
@@ -217,47 +216,47 @@ int main(void)
     mtype3.insertMember("d", HOFFSET(s3_t, d), PredType::NATIVE_INT);
     hsize_t dims = 3;
     mtype3.insertMember("x", HOFFSET(s3_t, x), ArrayType(PredType::NATIVE_INT, 1, &dims));
-    // 	  mtype3.insertMember("i", HOFFSET(s3_t, i), vlt_i); //this is not useful, since i is the vector object, not the
+    // 	  mtype3.insertMember("i", HOFFSET(s3_t, i), vlt_i); //this is not useful, since i is the std::vector object, not the
     // memory storage.
 
-    vector<s3_t> s3(LENGTH);
+    std::vector<s3_t> s3(LENGTH);
 
     s3[0].i.assign(3, 1);
     s3[3].i.assign(2, -1);
     dataset->read(s3.data(), mtype3);
 
-    cout << endl << "Field d : " << endl;
+    std::cout << std::endl << "Field d : " << std::endl;
     for (i = 0; i < LENGTH; i++)
-      cout << s3[i].d << " ";
-    cout << endl;
+      std::cout << s3[i].d << " ";
+    std::cout << std::endl;
 
-    cout << endl << "Field a : " << endl;
+    std::cout << std::endl << "Field a : " << std::endl;
     for (i = 0; i < LENGTH; i++)
-      cout << s3[i].a << " ";
-    cout << endl;
+      std::cout << s3[i].a << " ";
+    std::cout << std::endl;
 
-    cout << endl << "Field b : " << endl;
+    std::cout << std::endl << "Field b : " << std::endl;
     for (i = 0; i < LENGTH; i++)
-      cout << s3[i].b << " ";
-    cout << endl;
+      std::cout << s3[i].b << " ";
+    std::cout << std::endl;
 
-    cout << endl << "Field x : " << endl;
+    std::cout << std::endl << "Field x : " << std::endl;
     for (i = 0; i < LENGTH; i++)
     {
-      cout << i << ":";
+      std::cout << i << ":";
       for (auto x : s3[i].x)
-        cout << x << " ";
-      cout << endl;
+        std::cout << x << " ";
+      std::cout << std::endl;
     }
 
-    cout << endl << "Field i : " << endl;
+    std::cout << std::endl << "Field i : " << std::endl;
     for (i = 0; i < LENGTH; i++)
       if (s3[i].i.size())
       {
-        cout << i << ":";
+        std::cout << i << ":";
         for (auto x : s3[i].i)
-          cout << x << " ";
-        cout << endl;
+          std::cout << x << " ";
+        std::cout << std::endl;
       }
 
     /*
@@ -295,20 +294,20 @@ int main(void)
       for (offset[0] = 0; offset[0] < dim[0]; offset[0]++)
       {
         dspace.selectHyperslab(H5S_SELECT_SET, count, offset, stride, block);
-        cout << dset2.getVlenBufSize(vlt_i, dspace) / vlt_i.getSuper().getSize() << " ";
+        std::cout << dset2.getVlenBufSize(vlt_i, dspace) / vlt_i.getSuper().getSize() << " ";
       }
-      cout << endl;
-      cout << dset2.getStorageSize() << ',' << dset2.getInMemDataSize() << endl;
-      cout << vlt_i.getSize() << endl;
-      cout << dim[0] << endl;
+      std::cout << std::endl;
+      std::cout << dset2.getStorageSize() << ',' << dset2.getInMemDataSize() << std::endl;
+      std::cout << vlt_i.getSize() << std::endl;
+      std::cout << dim[0] << std::endl;
       hvl_t vl[dim[0]];
       dset2.read(vl, VarLenType(&PredType::NATIVE_FLOAT)); // this does not have to be the same as the storage type!
       for (i = 0; i < LENGTH; i++)
       {
-        cout << "data " << i << ":";
+        std::cout << "data " << i << ":";
         for (int j = 0; j < vl[i].len; j++)
-          cout << ((float *)vl[i].p)[j] << " ";
-        cout << endl;
+          std::cout << ((float *)vl[i].p)[j] << " ";
+        std::cout << std::endl;
       }
     }
   } // end of try block

--- a/src/test/test_h5compound2.cpp
+++ b/src/test/test_h5compound2.cpp
@@ -26,10 +26,10 @@ const int RANK = 1;
 
 #define ShowField(s, f)                                                                                                \
   {                                                                                                                    \
-    cout << endl << "Field " << #f << " : " << endl;                                                                   \
+    std::cout << std::endl << "Field " << #f << " : " << std::endl;                                                                   \
     for (int i = 0; i < LENGTH; i++)                                                                                   \
-      cout << s[i].f << " ";                                                                                           \
-    cout << endl;                                                                                                      \
+      std::cout << s[i].f << " ";                                                                                           \
+    std::cout << std::endl;                                                                                                      \
   }
 
 int main(void)
@@ -49,17 +49,17 @@ int main(void)
   CompType mtype2;
   mtype2.copy(mtype);
   mtype2.pack();
-  cout << mtype.getSize() << "," << mtype2.getSize() << endl;
+  std::cout << mtype.getSize() << "," << mtype2.getSize() << std::endl;
 
   hsize_t dim[] = {LENGTH};
-  vector<s_t> datain(LENGTH);
+  std::vector<s_t> datain(LENGTH);
   for (int i = 0; i < LENGTH; i++) /* init data*/
   {
     datain[i].a = i;
     datain[i].b = i * i;
     datain[i].c = -i;
   }
-  cout << "==========Data initialized=============\n";
+  std::cout << "==========Data initialized=============\n";
   ShowField(datain, a);
   ShowField(datain, b);
   ShowField(datain, c);
@@ -75,11 +75,11 @@ int main(void)
   /*read back*/
   H5File file(FILE_NAME, H5F_ACC_RDONLY);
   DataSet dset(file.openDataSet(DATASET_NAME));
-  vector<s_t> dataout(LENGTH);
+  std::vector<s_t> dataout(LENGTH);
 
   dset.read(dataout.data(), mtype);
 
-  cout << "\n===========Data Read==========\n";
+  std::cout << "\n===========Data Read==========\n";
   ShowField(dataout, a);
   ShowField(dataout, b);
   ShowField(dataout, c);
@@ -88,10 +88,10 @@ int main(void)
   btype.insertMember("b", 0, PredType::NATIVE_FLOAT);
   float b[LENGTH];
   dset.read(b, btype);
-  cout << "b \n";
+  std::cout << "b \n";
   for (int i = 0; i < LENGTH; i++)
-    cout << b[i] << " ";
-  cout << endl;
+    std::cout << b[i] << " ";
+  std::cout << std::endl;
   /*Output:
   ==========Data initialized=============
 

--- a/src/test/test_h5subset.cpp
+++ b/src/test/test_h5subset.cpp
@@ -75,12 +75,12 @@ int main(void)
 
     dataset.write(data, PredType::NATIVE_INT);
 
-    cout << endl << "Data Written to File:" << endl;
+    std::cout << std::endl << "Data Written to File:" << std::endl;
     for (j = 0; j < DIM0; j++)
     {
       for (i = 0; i < DIM1; i++)
-        cout << " " << data[j][i];
-      cout << endl;
+        std::cout << " " << data[j][i];
+      std::cout << std::endl;
     }
 
     dataspace.close();
@@ -130,10 +130,10 @@ int main(void)
     // Write a subset of data to the dataset, then read the
     // entire dataset back from the file.
 
-    cout << endl << "Write subset to file specifying: " << endl;
+    std::cout << std::endl << "Write subset to file specifying: " << std::endl;
 #define PRT(x) x[0] << "x" << x[1]
-    cout << "  offset=" << PRT(offset) << " stride=" << PRT(stride) << " count=" << PRT(count)
-         << " block=" << PRT(block) << endl;
+    std::cout << "  offset=" << PRT(offset) << " stride=" << PRT(stride) << " count=" << PRT(count)
+         << " block=" << PRT(block) << std::endl;
     for (j = 0; j < DIM0_SUB; j++)
     {
       for (i = 0; i < DIM1_SUB; i++)
@@ -142,27 +142,27 @@ int main(void)
 
     dataset.write(sdata, PredType::NATIVE_INT, memspace, dataspace);
     dataset.read(rdata, PredType::NATIVE_INT);
-    cout << endl << "Data in File after Subset is Written:" << endl;
+    std::cout << std::endl << "Data in File after Subset is Written:" << std::endl;
     for (i = 0; i < DIM0; i++)
     {
       for (j = 0; j < DIM1; j++)
-        cout << " " << rdata[i][j];
-      cout << endl;
+        std::cout << " " << rdata[i][j];
+      std::cout << std::endl;
     }
-    cout << endl;
+    std::cout << std::endl;
 
     offset[0] = 1;
     offset[1] = 0;
     dataspace.selectHyperslab(H5S_SELECT_SET, count, offset, stride, block);
     dataset.read(sdata, PredType::NATIVE_INT, memspace, dataspace);
-    cout << "Data read into Subset:" << endl;
+    std::cout << "Data read into Subset:" << std::endl;
     for (i = 0; i < DIM0_SUB; i++)
     {
       for (j = 0; j < DIM1_SUB; j++)
-        cout << " " << sdata[i][j];
-      cout << endl;
+        std::cout << " " << sdata[i][j];
+      std::cout << std::endl;
     }
-    cout << endl;
+    std::cout << std::endl;
     // It is not necessary to close these objects because close() will
     // be called when the object instances are going out of scope.
     dataspace.close();

--- a/src/test/test_init.cpp
+++ b/src/test/test_init.cpp
@@ -22,15 +22,6 @@ int main()
   {
     myclass c = myclass(), d;
     myclass a(0, 1, 2); // every thread executes the initializer
-#pragma omp single
-    {
-      //   cout<<c.x<<','<<c.y<<','<<c.z<<endl;
-      //   cout<<d.x<<','<<d.y<<','<<d.z<<endl;
-    }
   }
-  /*output:
-    0,1,4196688
-    0,1,4196128
-    */
   return 0;
 }

--- a/src/test/test_mpi.cpp
+++ b/src/test/test_mpi.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
     x = 1000;
   }
   MPI_Bcast(&x, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  cout << "x= " << x << " on " << myrank << endl;
+  std::cout << "x= " << x << " on " << myrank << std::endl;
 
   MPI_Request Req;
   const int nmax = 4831572;
@@ -28,21 +28,21 @@ int main(int argc, char **argv)
   }
   else
   {
-    vector<int> y(nmax);
-    vector<MPI_Request> Reqs(nmax);
+    std::vector<int> y(nmax);
+    std::vector<MPI_Request> Reqs(nmax);
     for (int i = 0; i < nmax; i++)
     {
       MPI_Irecv(&y[i], 1, MPI_INT, 0, 0, MPI_COMM_WORLD, &Reqs[i]);
       // 	  cout<<y[i]<<" ";
     }
-    cout << endl;
+    std::cout << std::endl;
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Waitall(
       Reqs.size(), Reqs.data(),
       MPI_STATUSES_IGNORE); // without this, the receive may not happen inside this block, where y is destroyed.
     // 	copy(y.cbegin(), y.cend(), ostream_iterator<int>(cout, ", "));
-    cout << y.front() << "," << y.back();
-    cout << endl;
+    std::cout << y.front() << "," << y.back();
+    std::cout << std::endl;
   }
 
   MPI_Finalize();

--- a/src/test/test_mpi_packed.cpp
+++ b/src/test/test_mpi_packed.cpp
@@ -18,17 +18,15 @@ int main(int argc, char **argv)
   {
     position = 0;
     MPI_Pack(&a, 2, MPI_INT, buff, BUF_LEN, &position, MPI_COMM_WORLD);
-    // 	cout<<position<<endl;
     MPI_Pack(j, MSG_LEN, MPI_INT, buff, BUF_LEN, &position, MPI_COMM_WORLD);
-    // 	cout<<position<<endl;
     MPI_Send(&position, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
     MPI_Send(buff, position, MPI_PACKED, 1, 0, MPI_COMM_WORLD);
-    cout << position << endl;
+    std::cout << position << std::endl;
   }
   else /* RECEIVER CODE */
   {
     MPI_Recv(&position, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-    cout << position << endl;
+    std::cout << position << std::endl;
     MPI_Recv(buff, position, MPI_PACKED, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
   }
 

--- a/src/test/test_mpi_reduce.cpp
+++ b/src/test/test_mpi_reduce.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
   else
     MPI_Reduce(&x, &x, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 
-  cout << "thread " << myrank << ": " << x << endl;
+  std::cout << "thread " << myrank << ": " << x << std::endl;
 
   MPI_Finalize();
   return 0;

--- a/src/test/test_ompfor.cpp
+++ b/src/test/test_ompfor.cpp
@@ -12,7 +12,6 @@ int main()
     printf("Thread %d: i=%d\n", ithread, i);
     if (1 == ithread)
       sleep(2);
-// #pragma omp barrier
 #pragma omp for // this will start to create tasks
     for (int j = 0; j < i; j++)
     { // the team of threads will loop through j together, distributing j-tasks.

--- a/src/test/test_ompnest.cpp
+++ b/src/test/test_ompnest.cpp
@@ -8,19 +8,19 @@ int main(int argc, char **argv)
   int n = atoi(argv[1]);
   // omp_set_nested(0);
   omp_set_max_active_levels(1); // max_active_level 0: no para; 1: single layer;
-  cout << "InPara:" << omp_in_parallel() << ", Level:" << omp_get_level() << ", nThreads:" << omp_get_num_threads()
-       << endl;
-  cout << "-----------------------------------\n";
+  std::cout << "InPara:" << omp_in_parallel() << ", Level:" << omp_get_level() << ", nThreads:" << omp_get_num_threads()
+       << std::endl;
+  std::cout << "-----------------------------------\n";
 #pragma omp parallel num_threads(2) if (n)
   {
 #pragma omp single
-    cout << "InPara:" << omp_in_parallel() << ", Level:" << omp_get_level() << ", nThreads:" << omp_get_num_threads()
-         << endl;
+    std::cout << "InPara:" << omp_in_parallel() << ", Level:" << omp_get_level() << ", nThreads:" << omp_get_num_threads()
+         << std::endl;
 #pragma omp parallel num_threads(3)
     {
 #pragma omp single
-      cout << "InPara:" << omp_in_parallel() << ", Level:" << omp_get_level() << ", nThreads:" << omp_get_num_threads()
-           << endl;
+      std::cout << "InPara:" << omp_in_parallel() << ", Level:" << omp_get_level() << ", nThreads:" << omp_get_num_threads()
+           << std::endl;
     }
   }
 

--- a/src/test/test_omptask.cpp
+++ b/src/test/test_omptask.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
         int x = work(i, j);
   }
   t1 = time(NULL);
-  cout << "outer for:" << t1 - t0 << endl;
+  std::cout << "outer for:" << t1 - t0 << std::endl;
 
   t0 = time(NULL);
 #pragma omp parallel num_threads(4)
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
         int x = work(i, j);
   }
   t1 = time(NULL);
-  cout << "inner for:" << t1 - t0 << endl;
+  std::cout << "inner for:" << t1 - t0 << std::endl;
 
   t0 = time(NULL);
   int x;
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
     for (int j = 0; j < i; j++)
       x += work(i, j);
   t1 = time(NULL);
-  cout << "serial:" << t1 - t0 << endl;
+  std::cout << "serial:" << t1 - t0 << std::endl;
 
   t0 = time(NULL);
 #pragma omp parallel num_threads(4)
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 #pragma omp taskwait
   }
   t1 = time(NULL);
-  cout << "task nowait: " << t1 - t0 << endl; // slow, because it's too fine-grained..
+  std::cout << "task nowait: " << t1 - t0 << std::endl; // slow, because it's too fine-grained..
 
 #pragma omp parallel num_threads(4)
   {
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
         int x = work(i, j);
   }
   t1 = time(NULL);
-  cout << "task: " << t1 - t0 << endl; // slowest!
+  std::cout << "task: " << t1 - t0 << std::endl; // slowest!
 
   return 0;
 }

--- a/src/test/test_ompvector.cpp
+++ b/src/test/test_ompvector.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv)
     n = atoi(argv[1]);
 #pragma omp parallel num_threads(3)
   {
-    static vector<int> x(3, 1); // by default, x is private, and is initialized properly
+    static std::vector<int> x(3, 1); // by default, x is private, and is initialized properly
     int y[n];                   // this is allowed by C99 and g++
     for (int i = 0; i < n; i++)
       y[i] = 1;
@@ -19,8 +19,8 @@ int main(int argc, char **argv)
 #pragma omp barrier
 #pragma omp critical
     {
-      cout << "(" << x[0] << "," << x[1] << "," << x[2] << ")  ";
-      cout << "(" << y[0] << "," << y[1] << "," << y[2] << ")" << endl;
+      std::cout << "(" << x[0] << "," << x[1] << "," << x[2] << ")  ";
+      std::cout << "(" << y[0] << "," << y[1] << "," << y[2] << ")" << std::endl;
     }
   }
   return 0;

--- a/src/test/test_parse.cpp
+++ b/src/test/test_parse.cpp
@@ -27,16 +27,16 @@ int main(int argc, char **argv)
   }
   HBTConfig.BroadCast(world, 0, snapshot_start, snapshot_end);
 
-  cout << HBTConfig.SnapshotPath << " from " << world.rank() << " of " << world.size() << " on " << env.processor_name()
-       << endl;
-  cout << HBTConfig.SnapshotIdList << " from " << world.rank() << " of " << world.size() << " on "
-       << env.processor_name() << endl;
-  cout << HBTConfig.IsSet[2] << " from " << world.rank() << " of " << world.size() << " on " << env.processor_name()
-       << endl;
-  cout << HBTConfig.GroupParticleIdMask << " from " << world.rank() << " of " << world.size() << " on "
-       << env.processor_name() << endl;
+  std::cout << HBTConfig.SnapshotPath << " from " << world.rank() << " of " << world.size() << " on " << env.processor_name()
+       << std::endl;
+  std::cout << HBTConfig.SnapshotIdList << " from " << world.rank() << " of " << world.size() << " on "
+       << env.processor_name() << std::endl;
+  std::cout << HBTConfig.IsSet[2] << " from " << world.rank() << " of " << world.size() << " on " << env.processor_name()
+       << std::endl;
+  std::cout << HBTConfig.GroupParticleIdMask << " from " << world.rank() << " of " << world.size() << " on "
+       << env.processor_name() << std::endl;
   long x = 0x1234567123456789;
-  cout << hex << (x & HBTConfig.GroupParticleIdMask) << "," << (x & 0x00000003FFFFFFFF) << endl;
+  std::cout << hex << (x & HBTConfig.GroupParticleIdMask) << "," << (x & 0x00000003FFFFFFFF) << std::endl;
 
   return 0;
 }

--- a/src/test/testnew.cpp
+++ b/src/test/testnew.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <new>
-// #include "../datatypes.h"
 class GB
 {
   long data[1024 * 1024 * 1024];

--- a/unit_tests/test_build_pos_vel.cpp
+++ b/unit_tests/test_build_pos_vel.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
         // To do more accurate checks we need to determine which particles
         // should have been used for the calculations. First store the indexes
         // of tracer type particles.
-        vector<int> part_index(0);
+        std::vector<int> part_index(0);
         int NumPart = 0;
         for (int i = 0; i < sub.Nbound; i += 1)
         {

--- a/unit_tests/test_locate_ids_unique.cpp
+++ b/unit_tests/test_locate_ids_unique.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     {
 
       // Create array of IDs
-      vector<HBTInt> all_ids(total_nr_ids);
+      std::vector<HBTInt> all_ids(total_nr_ids);
       for (int i = 0; i < total_nr_ids; i += 1)
         all_ids[i] = i;
 
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
       std::shuffle(all_ids.begin(), all_ids.end(), rng);
 
       // Create array of values as a function of their associated ID
-      vector<int> all_values(total_nr_ids);
+      std::vector<int> all_values(total_nr_ids);
       for (int i = 0; i < total_nr_ids; i += 1)
         all_values[i] = 1000 * all_ids[i];
 

--- a/unit_tests/test_multi_neighbour_search.cpp
+++ b/unit_tests/test_multi_neighbour_search.cpp
@@ -85,7 +85,7 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTInt nr_ngb, HBTReal boxs
 {
   std::cout << "Start test with N=" << N << ", Nsearch = " << Nsearch << ", boxsize = " << boxsize;
   if(periodic)std::cout << " (periodic)";
-  std::cout << endl;
+  std::cout << std::endl;
 
   // Make a random snapshot
   RandomSnapshot_t snap(N, boxsize, rng);
@@ -112,13 +112,13 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTInt nr_ngb, HBTReal boxs
   std::vector<std::vector<HBTInt>> ngb_idx(Nsearch);
 
   // Carry out the search
-  cout << "  Finding neighbours using octree" << std::endl;
+  std::cout << "  Finding neighbours using octree" << std::endl;
   for(HBTInt i=0; i<Nsearch; i+=1)
     ngb_idx[i] = tree.NearestNeighbours(centre[i], nr_ngb, 0.01);
 
   // Now check the results by brute force:
   // There should be no points closer than the neighbours we found.
-  cout << "  Checking neighbour distances" << std::endl;
+  std::cout << "  Checking neighbour distances" << std::endl;
   for(HBTInt i=0; i<Nsearch; i+=1) {
 
     // Compute distance to the most distant identified neighbour of this centre
@@ -153,7 +153,7 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTInt nr_ngb, HBTReal boxs
       }
     }
   }
-  cout << "  Test done." << std::endl;
+  std::cout << "  Test done." << std::endl;
 }
 
 
@@ -191,5 +191,5 @@ int main(int argc, char *argv[]) {
             }
         }
     }
-  std::cout << "All tests done." << endl;
+  std::cout << "All tests done." << std::endl;
 }

--- a/unit_tests/test_myalltoall.cpp
+++ b/unit_tests/test_myalltoall.cpp
@@ -67,14 +67,14 @@ int main(int argc, char *argv[])
     std::vector<int> recvbuf(nr_recv);
 
     // Set up iterators
-    typedef vector<int>::iterator InputIterator_t;
+    typedef std::vector<int>::iterator InputIterator_t;
     std::vector<InputIterator_t> input_iterators(comm_size);
     for (int i = 0; i < comm_size; i += 1)
     {
       input_iterators[i] = sendbuf.begin() + senddispls[i];
     }
 
-    typedef vector<int>::iterator OutputIterator_t;
+    typedef std::vector<int>::iterator OutputIterator_t;
     std::vector<OutputIterator_t> output_iterators(comm_size);
     for (int i = 0; i < comm_size; i += 1)
     {

--- a/unit_tests/test_neighbour_search.cpp
+++ b/unit_tests/test_neighbour_search.cpp
@@ -85,7 +85,7 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTReal boxsize, bool perio
 {
   std::cout << "Start test with N=" << N << ", Nsearch = " << Nsearch << ", boxsize = " << boxsize;
   if(periodic)std::cout << " (periodic)";
-  std::cout << endl;
+  std::cout << std::endl;
 
   // Make a random snapshot
   RandomSnapshot_t snap(N, boxsize, rng);
@@ -112,7 +112,7 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTReal boxsize, bool perio
   std::vector<HBTInt> ngb_idx(Nsearch);
 
   // Carry out the search
-  cout << "  Finding neighbours using octree" << std::endl;
+  std::cout << "  Finding neighbours using octree" << std::endl;
   for(HBTInt i=0; i<Nsearch; i+=1) {
     ngb_idx[i] = tree.NearestNeighbour(centre[i], 0.01);
     verify(ngb_idx[i] >= 0);
@@ -121,7 +121,7 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTReal boxsize, bool perio
 
   // Now check the results by brute force:
   // There should be no points closer than the neighbour we found.
-  cout << "  Checking neighbour distances" << std::endl;
+  std::cout << "  Checking neighbour distances" << std::endl;
   for(HBTInt i=0; i<Nsearch; i+=1) {
 
     // Compute distance (squared) to the identified neighbour
@@ -139,7 +139,7 @@ void test_neighbour_search(HBTInt N, HBTInt Nsearch, HBTReal boxsize, bool perio
     }
   }
 
-  cout << "  Test done." << std::endl;
+  std::cout << "  Test done." << std::endl;
 }
 
 
@@ -171,5 +171,5 @@ int main(int argc, char *argv[]) {
           test_neighbour_search(N, Nsearch, boxsize, /* periodic = */ true, rng);
         }
     }
-  std::cout << "All tests done." << endl;
+  std::cout << "All tests done." << std::endl;
 }


### PR DESCRIPTION
I was getting annoyed at the inconsistency between things like accumulate vs std::accumulate and vector vs std::vector.

I have removed all instances of `using namespace std;` and proceeded to add all required `std::`.