### PR TITLE
Rename variable to be more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ If you use HBT-HERONS catalogues in your work, please cite the following papers:
  * [Assessing subhalo finders in cosmological hydrodynamical simulations](https://ui.adsabs.harvard.edu/abs/2025arXiv250206932F/abstract)
  * [HBT+: an improved code for finding subhaloes and building merger trees in cosmological simulations](https://ui.adsabs.harvard.edu/abs/2018MNRAS.474..604H/abstract)
  * [Resolving subhaloes' lives with the Hierarchical Bound-Tracing algorithm](https://ui.adsabs.harvard.edu/abs/2012MNRAS.427.2437H/abstract)
+
+## Documentation
+
+The documentation is built with [MkDocs](https://www.mkdocs.org/) using the Material theme. Install the required packages with:
+
+```bash
+pip install mkdocs mkdocs-material mkdocs-video
+```
+
+To build the static site run:
+
+```bash
+mkdocs build   # build static site into ./site/
+```

--- a/docs/examples/internal_halo_population.md
+++ b/docs/examples/internal_halo_population.md
@@ -86,8 +86,8 @@ Depth  = subhaloes["Depth"]
 ParentTrackId = subhaloes["NestedParentTrackId"]
 
 # Select the most massive subhalo in the box and its host halo
-TargetTrackId = Mbound.argmax()
-HostHaloId = subhaloes["HostHaloId"][TargetTrackId]
+most_massive_idx = Mbound.argmax()
+HostHaloId = subhaloes["HostHaloId"][most_massive_idx]
 
 # Select all subhaloes that share the same host halo (including central)
 subhaloes_in_halo = subhaloes["HostHaloId"] == HostHaloId

--- a/docs/examples/population_level_statistics.md
+++ b/docs/examples/population_level_statistics.md
@@ -18,7 +18,7 @@ use_sorted_catalogues = True
 catalogue = HBTReader(f"{SORTED_CATALOGUE_BASE_PATH if use_sorted_catalogues else RAW_CATALOGUE_BASE_PATH}",
                       sorted_catalogues=use_sorted_catalogues)
 
-Mbound = catalogue.LoadSubhaloProperties(property_selection=["Mbound"])["Mbound"] * catalogue.GetMassUnits_Msunh()
+Mbound = catalogue.LoadSubhaloProperties(properties=["Mbound"])["Mbound"] * catalogue.GetMassUnits_Msunh()
 
 # Make the plot
 fig, ax1 = plt.subplots(1)
@@ -47,7 +47,7 @@ plt.show()
                         sorted_catalogues=use_sorted_catalogues)
 
     # Load required data
-    subhalo_data = catalogue.LoadSubhaloProperties(property_selection=["Mbound", "HostHaloId"])
+    subhalo_data = catalogue.LoadSubhaloProperties(properties=["Mbound", "HostHaloId"])
     Mbound     = subhalo_data["Mbound"] * catalogue.GetMassUnits_Msunh()
     HostHaloId = subhalo_data["HostHaloId"]
 
@@ -86,7 +86,7 @@ catalogue = HBTReader(f"{SORTED_CATALOGUE_BASE_PATH if use_sorted_catalogues els
 
 
 # Load required data
-Mpeak = catalogue.LoadSubhaloProperties(property_selection=["LastMaxMass"])["LastMaxMass"] * catalogue.GetMassUnits_Msunh()
+Mpeak = catalogue.LoadSubhaloProperties(properties=["LastMaxMass"])["LastMaxMass"] * catalogue.GetMassUnits_Msunh()
 
 # Make the plot
 fig, ax1 = plt.subplots(1)
@@ -114,7 +114,7 @@ plt.show()
     catalogue = HBTReader(f"{SORTED_CATALOGUE_BASE_PATH if use_sorted_catalogues else RAW_CATALOGUE_BASE_PATH}",
                         sorted_catalogues=use_sorted_catalogues)
 
-    subhalo_data = catalogue.LoadSubhaloProperties(property_selection=["LastMaxMass", "SnapshotOfDeath"])
+    subhalo_data = catalogue.LoadSubhaloProperties(properties=["LastMaxMass", "SnapshotOfDeath"])
     Mpeak = subhalo_data["LastMaxMass"] * catalogue.GetMassUnits_Msunh()
     SnapshotOfDeath = subhalo_data["SnapshotOfDeath"]
 
@@ -150,7 +150,7 @@ catalogue = HBTReader(f"{SORTED_CATALOGUE_BASE_PATH if use_sorted_catalogues els
                       sorted_catalogues=use_sorted_catalogues)
 
 # Load required data
-SnapshotOfDeath = catalogue.LoadSubhaloProperties(property_selection=["SnapshotOfDeath"])["SnapshotOfDeath"]
+SnapshotOfDeath = catalogue.LoadSubhaloProperties(properties=["SnapshotOfDeath"])["SnapshotOfDeath"]
 
 # Only keep orphan subhaloes
 orphan_subhaloes_mask = SnapshotOfDeath != -1
@@ -183,7 +183,7 @@ plt.show()
                         sorted_catalogues=use_sorted_catalogues)
 
     # Load required data
-    subhalo_data = catalogue.LoadSubhaloProperties(property_selection=["SnapshotOfDeath", "SnapshotOfSink"])
+    subhalo_data = catalogue.LoadSubhaloProperties(properties=["SnapshotOfDeath", "SnapshotOfSink"])
     SnapshotOfDeath = subhalo_data["SnapshotOfDeath"]
     SnapshotOfSink = subhalo_data["SnapshotOfSink"]
 


### PR DESCRIPTION
The examples should not assume people are using the sorted catalogues, and so the variable names should reflect that. 